### PR TITLE
Experimental Kimchi support

### DIFF
--- a/mopro-core/Cargo.toml
+++ b/mopro-core/Cargo.toml
@@ -40,6 +40,8 @@ ark-groth16 = { version = "=0.4.0", default-features = false, features = [
 ark-relations = { version = "0.4", default-features = false }
 ark-zkey = { path = "../ark-zkey" }
 
+kimchi = { path = "../../o1-labs/proof-systems/kimchi" }
+
 # Error handling
 thiserror = "=1.0.39"
 color-eyre = "=0.6.2"

--- a/mopro-core/Cargo.toml
+++ b/mopro-core/Cargo.toml
@@ -40,7 +40,13 @@ ark-groth16 = { version = "=0.4.0", default-features = false, features = [
 ark-relations = { version = "0.4", default-features = false }
 ark-zkey = { path = "../ark-zkey" }
 
+# This should correspond to https://github.com/oskarth/proof-systems
+# Some hacks for embedding SRS
 kimchi = { path = "../../o1-labs/proof-systems/kimchi" }
+mina-curves = { path = "../../o1-labs/proof-systems/curves", version = "0.1.0" }
+
+# XXX Old version
+# ark-ff = { version = "0.3.0" }
 
 # Error handling
 thiserror = "=1.0.39"

--- a/mopro-core/src/middleware/kimchi/mod.rs
+++ b/mopro-core/src/middleware/kimchi/mod.rs
@@ -1,0 +1,38 @@
+use crate::MoproError;
+use kimchi::bench::{self, BenchmarkCtx};
+use std::time::Instant;
+
+fn hello() {
+    println!("Hello, world!");
+}
+
+// TODO: Separate out proof generation and verification
+
+pub fn bench() {
+    // context created in 21.2235 ms
+    let start = Instant::now();
+    let srs_size = 4;
+    let ctx = BenchmarkCtx::new(srs_size);
+    println!("testing bench code for SRS of size {srs_size}");
+    println!("context created in {}s", start.elapsed().as_secs());
+
+    // proof created in 7.1227 ms
+    let start = Instant::now();
+    let (proof, public_input) = ctx.create_proof();
+    println!("proof created in {}s", start.elapsed().as_secs());
+
+    // proof verified in 1.710 ms
+    let start = Instant::now();
+    ctx.batch_verification(&vec![(proof, public_input)]);
+    println!("proof verified in {}", start.elapsed().as_secs());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kimchi_bench() {
+        bench();
+    }
+}

--- a/mopro-core/src/middleware/kimchi/mod.rs
+++ b/mopro-core/src/middleware/kimchi/mod.rs
@@ -1,12 +1,67 @@
 use crate::MoproError;
-use kimchi::bench::{self, BenchmarkCtx};
-use std::time::Instant;
+//use ark_ff::fields::Fp256;
+//use ark_ff::{biginteger::BigInteger256 as BigInteger, Fp256, FpParameters};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use kimchi::{
+    bench::{self, BenchmarkCtx},
+    poly_commitment::evaluation_proof::OpeningProof,
+    proof::ProverProof,
+};
+use mina_curves::pasta::fields::FpParameters;
+use mina_curves::pasta::{Fp, Vesta, VestaParameters};
+use serde::{Deserialize, Serialize};
+use std::time::Instant; // Import serde traits
 
-fn hello() {
-    println!("Hello, world!");
+// XXX: This is hacky just to get some basic proof/verification of Kimchi setup going
+
+//#[derive(CanonicalSerialize, CanonicalDeserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SerializableProverProof(pub ProverProof<Vesta, OpeningProof<Vesta>>);
+
+// XXX: Something wrong with serialization traits
+// pub struct SerializablePublicInputs(pub Vec<Fp256<FpParameters>>);
+//#[derive(CanonicalSerialize, CanonicalDeserialize, Clone, Debug)]
+// #[derive(Serialize, Deserialize, Clone, Debug)]
+// pub struct SerializablePublicInputs(pub Vec<Fp>);
+
+// TODO: Public inputs should be part of API but couldn't get serialization to work within timebox
+pub struct KimchiContext {
+    ctx: BenchmarkCtx,
+    public_inputs: Vec<Fp>, // XXX: Added to store public inputs
 }
 
-// TODO: Separate out proof generation and verification
+impl KimchiContext {
+    // Initializes the benchmark context
+    pub fn bench_init(srs_size: u32) -> Self {
+        let ctx = BenchmarkCtx::new(srs_size);
+        KimchiContext {
+            ctx,
+            public_inputs: Vec::new(),
+        }
+    }
+
+    // Creates a proof and updates public inputs in the context
+    pub fn create_proof(&mut self) -> SerializableProverProof {
+        let start = Instant::now();
+        let (proof, public_input) = self.ctx.create_proof();
+        self.public_inputs = public_input; // Store the public inputs in the context
+        println!("proof created in {}s", start.elapsed().as_secs());
+        SerializableProverProof(proof)
+    }
+
+    // Verifies a proof using stored public inputs
+    pub fn verify_proof(&self, proof: SerializableProverProof) -> bool {
+        let start = Instant::now();
+        let proof = proof.0;
+        let result = self
+            .ctx
+            .batch_verification(&[(proof, self.public_inputs.clone())]);
+        println!("proof verified in {}s", start.elapsed().as_secs());
+
+        // XXX Assume it works? No result type
+        return true;
+    }
+}
 
 pub fn bench() {
     // context created in 21.2235 ms
@@ -34,5 +89,20 @@ mod tests {
     #[test]
     fn test_kimchi_bench() {
         bench();
+    }
+
+    #[test]
+    fn test_kimchi_context() {
+        // Initialize the KimchiContext with a sample SRS size
+        let mut ctx = KimchiContext::bench_init(4);
+
+        // Create a proof and store it in the context
+        let proof = ctx.create_proof();
+
+        // Verify the proof and assert that the verification is successful
+        assert!(
+            ctx.verify_proof(proof),
+            "Proof verification should be successful"
+        );
     }
 }

--- a/mopro-core/src/middleware/mod.rs
+++ b/mopro-core/src/middleware/mod.rs
@@ -1,1 +1,2 @@
 pub mod circom;
+pub mod kimchi;

--- a/mopro-ffi/src/lib.rs
+++ b/mopro-ffi/src/lib.rs
@@ -1,4 +1,5 @@
 use mopro_core::middleware::circom;
+use mopro_core::middleware::kimchi;
 use mopro_core::MoproError;
 
 use num_bigint::BigInt;
@@ -144,6 +145,12 @@ fn hello() -> String {
 // fn run_example(wasm_path: String, r1cs_path: String) -> Result<(), MoproError> {
 //     circom::run_example(wasm_path.as_str(), r1cs_path.as_str())
 // }
+
+// Kimchi stuff
+pub fn kimchi_bench() -> Result<(), MoproError> {
+    kimchi::bench();
+    Ok(())
+}
 
 uniffi::include_scaffolding!("mopro");
 

--- a/mopro-ffi/src/mopro.udl
+++ b/mopro-ffi/src/mopro.udl
@@ -7,6 +7,9 @@ namespace mopro {
 
   [Throws=MoproError]
   GenerateProofResult generate_proof2(record<string, sequence<string>> circuit_inputs);
+
+  [Throws=MoproError]
+  void kimchi_bench();
 };
 
 dictionary SetupResult {

--- a/mopro-ffi/src/mopro.udl
+++ b/mopro-ffi/src/mopro.udl
@@ -23,7 +23,7 @@ dictionary GenerateProofResult {
 
 [Error]
 enum MoproError {
-  "CircomError",
+  "CircomError"
 };
 
 interface MoproCircom {
@@ -37,4 +37,14 @@ interface MoproCircom {
 
   [Throws=MoproError]
   boolean verify_proof(bytes proof, bytes public_input);
+};
+
+interface MoproKimchi {
+    constructor();
+
+    [Throws=MoproError]
+    bytes create_proof();
+
+    [Throws=MoproError]
+    boolean verify_proof(bytes proof);
 };

--- a/mopro-ffi/tests/bindings/test_kimchi.swift
+++ b/mopro-ffi/tests/bindings/test_kimchi.swift
@@ -13,5 +13,28 @@ func testKimchiBench() {
     }
 }
 
+func testMoproKimchi() {
+    do {
+        // Create a new instance of MoproKimchi
+        let moproKimchi = MoproKimchi()
+
+        // Create a proof
+        let serializedProof = try moproKimchi.createProof()
+        print("Proof created successfully. Size: \(serializedProof.count)")
+
+        // Verify the proof
+        let isProofValid = try moproKimchi.verifyProof(proof: serializedProof)
+        print("Proof verification result: \(isProofValid)")
+
+    } catch let error as MoproError {
+        print("MoproError: \(error)")
+    } catch {
+        print("Unexpected error: \(error)")
+    }
+}
+
 // Execute the test
 testKimchiBench()
+
+// Execute the test
+testMoproKimchi()

--- a/mopro-ffi/tests/bindings/test_kimchi.swift
+++ b/mopro-ffi/tests/bindings/test_kimchi.swift
@@ -1,0 +1,17 @@
+import mopro
+import Foundation
+
+func testKimchiBench() {
+    do {
+        // Call kimchi_bench function
+        try kimchiBench()
+        print("kimchiBeench executed successfully")
+    } catch let error as MoproError {
+        print("MoproError: \(error)")
+    } catch {
+        print("Unexpected error: \(error)")
+    }
+}
+
+// Execute the test
+testKimchiBench()

--- a/mopro-ffi/tests/test_generated_bindings.rs
+++ b/mopro-ffi/tests/test_generated_bindings.rs
@@ -1,9 +1,10 @@
 uniffi::build_foreign_language_testcases!(
-    "tests/bindings/test_mopro.swift",
+    //"tests/bindings/test_mopro.swift",
     //    "tests/bindings/test_mopro.kts",
     //    "tests/bindings/test_mopro.rb",
     //    "tests/bindings/test_mopro.py",
-    "tests/bindings/test_mopro_keccak.swift",
-    "tests/bindings/test_mopro_keccak2.swift",
-    "tests/bindings/test_mopro_rsa.swift",
+    // "tests/bindings/test_mopro_keccak.swift",
+    // "tests/bindings/test_mopro_keccak2.swift",
+    // "tests/bindings/test_mopro_rsa.swift",
+    "tests/bindings/test_kimchi.swift",
 );

--- a/mopro-ios/MoproKit/Bindings/mopro.swift
+++ b/mopro-ios/MoproKit/Bindings/mopro.swift
@@ -684,6 +684,12 @@ public func generateProof2(circuitInputs: [String: [String]]) throws -> Generate
     )
 }
 
+public func kimchiBench() throws {
+    try rustCallWithError(FfiConverterTypeMoproError.lift) {
+        uniffi_mopro_fn_func_kimchi_bench($0)
+    }
+}
+
 private enum InitializationResult {
     case ok
     case contractVersionMismatch
@@ -710,6 +716,9 @@ private var initializationResult: InitializationResult {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_mopro_checksum_func_generate_proof2() != 6969 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_mopro_checksum_func_kimchi_bench() != 3758 {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_mopro_checksum_method_moprocircom_setup() != 40345 {

--- a/mopro-ios/MoproKit/Example/MoproKit.xcodeproj/project.pbxproj
+++ b/mopro-ios/MoproKit/Example/MoproKit.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		7A38AEC233A3880A843B0133 /* Pods_MoproKit_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BE5A40EAC7D019B9C7566CA /* Pods_MoproKit_Example.framework */; };
 		CE2C1B8C2AFFCC5E002AF8BC /* main.wasm in Resources */ = {isa = PBXBuildFile; fileRef = CE2C1B8B2AFFCC5E002AF8BC /* main.wasm */; };
 		CE2C1B8D2AFFCC5E002AF8BC /* main.wasm in Resources */ = {isa = PBXBuildFile; fileRef = CE2C1B8B2AFFCC5E002AF8BC /* main.wasm */; };
+		CE2C1B8F2AFFE371002AF8BC /* KimchiViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2C1B8E2AFFE371002AF8BC /* KimchiViewController.swift */; };
+		CE2C1B902AFFE371002AF8BC /* KimchiViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2C1B8E2AFFE371002AF8BC /* KimchiViewController.swift */; };
 		CE5A5C062AD43A790074539D /* keccak256_256_test.wasm in Resources */ = {isa = PBXBuildFile; fileRef = CE5A5C052AD43A790074539D /* keccak256_256_test.wasm */; };
 		CE5A5C072AD43A790074539D /* keccak256_256_test.wasm in Resources */ = {isa = PBXBuildFile; fileRef = CE5A5C052AD43A790074539D /* keccak256_256_test.wasm */; };
 		CE5A5C092AD43A860074539D /* keccak256_256_test.r1cs in Resources */ = {isa = PBXBuildFile; fileRef = CE5A5C082AD43A860074539D /* keccak256_256_test.r1cs */; };
@@ -63,6 +65,7 @@
 		B4016A34BBB20BC381CCFC2D /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		C61628A63419B5C140B24AF7 /* Pods-MoproKit_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MoproKit_Example.debug.xcconfig"; path = "Target Support Files/Pods-MoproKit_Example/Pods-MoproKit_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		CE2C1B8B2AFFCC5E002AF8BC /* main.wasm */ = {isa = PBXFileReference; lastKnownFileType = file; name = main.wasm; path = "../../../../../mopro-core/examples/circom/rsa/target/main_js/main.wasm"; sourceTree = "<group>"; };
+		CE2C1B8E2AFFE371002AF8BC /* KimchiViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KimchiViewController.swift; path = MoproKit/KimchiViewController.swift; sourceTree = SOURCE_ROOT; };
 		CE5A5C052AD43A790074539D /* keccak256_256_test.wasm */ = {isa = PBXFileReference; lastKnownFileType = file; name = keccak256_256_test.wasm; path = "../../../../../mopro-core/examples/circom/keccak256/target/keccak256_256_test_js/keccak256_256_test.wasm"; sourceTree = "<group>"; };
 		CE5A5C082AD43A860074539D /* keccak256_256_test.r1cs */ = {isa = PBXFileReference; lastKnownFileType = file; name = keccak256_256_test.r1cs; path = "../../../../../mopro-core/examples/circom/keccak256/target/keccak256_256_test.r1cs"; sourceTree = "<group>"; };
 		CEA2D12E2AB96A7A00F292D2 /* multiplier2.wasm */ = {isa = PBXFileReference; lastKnownFileType = file; name = multiplier2.wasm; path = "../../../../../mopro-core/examples/circom/multiplier2/target/multiplier2_js/multiplier2.wasm"; sourceTree = "<group>"; };
@@ -179,6 +182,7 @@
 		CEA2D1282AB9681E00F292D2 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				CE2C1B8E2AFFE371002AF8BC /* KimchiViewController.swift */,
 				CE2C1B8B2AFFCC5E002AF8BC /* main.wasm */,
 				CE5A5C082AD43A860074539D /* keccak256_256_test.r1cs */,
 				CE5A5C052AD43A790074539D /* keccak256_256_test.wasm */,
@@ -407,6 +411,7 @@
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
 				CEB804502AFF81960063F091 /* KeccakSetupViewController.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
+				CE2C1B8F2AFFE371002AF8BC /* KimchiViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -416,6 +421,7 @@
 			files = (
 				2A6E5BAF2AF499460052A601 /* CircomTests.swift in Sources */,
 				2A418AB02AF4B1200004B747 /* CircomUITests.swift in Sources */,
+				CE2C1B902AFFE371002AF8BC /* KimchiViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mopro-ios/MoproKit/Example/MoproKit/KimchiViewController.swift
+++ b/mopro-ios/MoproKit/Example/MoproKit/KimchiViewController.swift
@@ -1,0 +1,122 @@
+//
+//  ViewController.swift
+//  MoproKit
+//
+//  Created by 1552237 on 09/16/2023.
+//  Copyright (c) 2023 1552237. All rights reserved.
+//
+
+import UIKit
+import MoproKit
+
+class KimchiViewController: UIViewController {
+
+    var benchButton = UIButton(type: .system)
+    // var initButton = UIButton(type: .system)
+    // var proveButton = UIButton(type: .system)
+    // var verifyButton = UIButton(type: .system)
+    var textView = UITextView()
+
+    //let moproCircom = MoproKit.MoproCircom()
+    //var setupResult: SetupResult?
+    // var generatedProof: Data?
+    // var publicInputs: Data?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Set title
+        let title = UILabel()
+        title.text = "Kimchi"
+        title.textColor = .white
+        title.textAlignment = .center
+        navigationItem.titleView = title
+        navigationController?.navigationBar.isHidden = false
+        navigationController?.navigationBar.prefersLargeTitles = true
+
+        setupUI()
+    }
+
+   func setupUI() {
+        benchButton.setTitle("Bench", for: .normal)
+        // initButton.setTitle("Init", for: .normal)
+        // proveButton.setTitle("Prove", for: .normal)
+        // verifyButton.setTitle("Verify", for: .normal)
+
+        // proveButton.isEnabled = true
+        // verifyButton.isEnabled = false
+        // textView.isEditable = false
+
+        // Setup actions for buttons
+        benchButton.addTarget(self, action: #selector(runBenchAction), for: .touchUpInside)
+        // initButton.addTarget(self, action: #selector(runInitAction), for: .touchUpInside)
+        // proveButton.addTarget(self, action: #selector(runProveAction), for: .touchUpInside)
+        // verifyButton.addTarget(self, action: #selector(runVerifyAction), for: .touchUpInside)
+
+        benchButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+        // initButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+        // proveButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+        // verifyButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+
+        //let stackView = UIStackView(arrangedSubviews: [initButton, proveButton, verifyButton, textView])
+        let stackView = UIStackView(arrangedSubviews: [benchButton, textView])
+        stackView.axis = .vertical
+        stackView.spacing = 10
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stackView)
+
+        // Make text view visible
+        textView.heightAnchor.constraint(equalToConstant: 200).isActive = true
+
+        NSLayoutConstraint.activate([
+            stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20)
+        ])
+    }
+
+    @objc func runBenchAction() {
+        // Update the textView on the main thread
+        DispatchQueue.main.async {
+            self.textView.text += "Running bench library\n"
+        }
+
+        // Execute long-running tasks in the background
+        DispatchQueue.global(qos: .userInitiated).async {
+            // Record start time
+            let start = CFAbsoluteTimeGetCurrent()
+
+            do {
+                //try initializeMopro()
+                try kimchiBench()
+
+                // Record end time and compute duration
+                let end = CFAbsoluteTimeGetCurrent()
+                let timeTaken = end - start
+
+                // Again, update the UI on the main thread
+                DispatchQueue.main.async {
+                    self.textView.text += "Running bench took \(timeTaken) seconds.\n"
+                }
+            } catch {
+                // Handle errors - update UI on main thread
+                DispatchQueue.main.async {
+                    self.textView.text += "An error occurred during initialization: \(error)\n"
+                }
+            }
+        }
+    }
+
+    @objc func runInitAction() {
+        // Logic for init
+    }
+
+    @objc func runProveAction() {
+        // Logic for prove
+    }
+
+    @objc func runVerifyAction() {
+        // Logic for verify
+    }
+}

--- a/mopro-ios/MoproKit/Example/MoproKit/KimchiViewController.swift
+++ b/mopro-ios/MoproKit/Example/MoproKit/KimchiViewController.swift
@@ -12,14 +12,15 @@ import MoproKit
 class KimchiViewController: UIViewController {
 
     var benchButton = UIButton(type: .system)
-    // var initButton = UIButton(type: .system)
-    // var proveButton = UIButton(type: .system)
-    // var verifyButton = UIButton(type: .system)
+    //var initButton = UIButton(type: .system)
+    var proveButton = UIButton(type: .system)
+    var verifyButton = UIButton(type: .system)
     var textView = UITextView()
 
-    //let moproCircom = MoproKit.MoproCircom()
-    //var setupResult: SetupResult?
-    // var generatedProof: Data?
+    // TODO: Put this in init
+    let moproKimchi = MoproKit.MoproKimchi()
+
+    var generatedProof: Data?
     // var publicInputs: Data?
 
     override func viewDidLoad() {
@@ -40,26 +41,26 @@ class KimchiViewController: UIViewController {
    func setupUI() {
         benchButton.setTitle("Bench", for: .normal)
         // initButton.setTitle("Init", for: .normal)
-        // proveButton.setTitle("Prove", for: .normal)
-        // verifyButton.setTitle("Verify", for: .normal)
+        proveButton.setTitle("Prove", for: .normal)
+        verifyButton.setTitle("Verify", for: .normal)
 
-        // proveButton.isEnabled = true
-        // verifyButton.isEnabled = false
-        // textView.isEditable = false
+        proveButton.isEnabled = true
+        verifyButton.isEnabled = false
+        textView.isEditable = false
 
         // Setup actions for buttons
         benchButton.addTarget(self, action: #selector(runBenchAction), for: .touchUpInside)
         // initButton.addTarget(self, action: #selector(runInitAction), for: .touchUpInside)
-        // proveButton.addTarget(self, action: #selector(runProveAction), for: .touchUpInside)
-        // verifyButton.addTarget(self, action: #selector(runVerifyAction), for: .touchUpInside)
+        proveButton.addTarget(self, action: #selector(runProveAction), for: .touchUpInside)
+        verifyButton.addTarget(self, action: #selector(runVerifyAction), for: .touchUpInside)
 
         benchButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
         // initButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
-        // proveButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
-        // verifyButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+        proveButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+        verifyButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
 
         //let stackView = UIStackView(arrangedSubviews: [initButton, proveButton, verifyButton, textView])
-        let stackView = UIStackView(arrangedSubviews: [benchButton, textView])
+        let stackView = UIStackView(arrangedSubviews: [benchButton, proveButton, verifyButton, textView])
         stackView.axis = .vertical
         stackView.spacing = 10
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -114,9 +115,43 @@ class KimchiViewController: UIViewController {
 
     @objc func runProveAction() {
         // Logic for prove
+        // Create a proof
+        do {
+            let start = CFAbsoluteTimeGetCurrent()
+            generatedProof = try moproKimchi.createProof()
+            let end = CFAbsoluteTimeGetCurrent()
+            let timeTaken = end - start
+            print("Proof creation took \(timeTaken) seconds.")
+            textView.text += "Proof creation took \(timeTaken) seconds.\n"
+            verifyButton.isEnabled = true
+        } catch let error as MoproError {
+            print("MoproError: \(error)")
+            textView.text += "MoproError: \(error)\n"
+        } catch {
+            print("Unexpected error: \(error)")
+            textView.text += "Unexpected error: \(error)\n"
+        }
     }
 
     @objc func runVerifyAction() {
-        // Logic for verify
+         // Verify the proof
+
+         guard let proof = generatedProof else {
+            print("Proof has not been generated yet.")
+            return
+        }
+         do {
+            let start = CFAbsoluteTimeGetCurrent()
+            let isProofValid = try moproKimchi.verifyProof(proof: proof)
+            let end = CFAbsoluteTimeGetCurrent()
+            let timeTaken = end - start
+            textView.text += "Proof verification took: \(timeTaken)\n"
+        } catch let error as MoproError {
+            print("MoproError: \(error)")
+            textView.text += "MoproError: \(error)\n"
+        } catch {
+            print("Unexpected error: \(error)")
+            textView.text += "Unexpected error: \(error)\n"
+        }
     }
 }

--- a/mopro-ios/MoproKit/Example/MoproKit/ViewController.swift
+++ b/mopro-ios/MoproKit/Example/MoproKit/ViewController.swift
@@ -16,6 +16,7 @@ class ViewController: UIViewController {
     let keccakSetupButton = UIButton(type: .system)
     let keccakZkeyButton = UIButton(type: .system)
     let rsaButton = UIButton(type: .system)
+    let kimchiButton = UIButton(type: .system)
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -43,16 +44,18 @@ class ViewController: UIViewController {
         rsaButton.setTitle("RSA", for: .normal)
         rsaButton.addTarget(self, action: #selector(openRSA), for: .touchUpInside)
 
+        kimchiButton.setTitle("Kimchi", for: .normal)
+        kimchiButton.addTarget(self, action: #selector(openKimchi), for: .touchUpInside)
 
-       keccakSetupButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
-       keccakZkeyButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
-       rsaButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+        keccakSetupButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+        keccakZkeyButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+        rsaButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+        kimchiButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
 
 //        self.title = "Mopro Examples"
 //        navigationController?.navigationBar.prefersLargeTitles = true
 
-
-        let stackView = UIStackView(arrangedSubviews: [keccakSetupButton, keccakZkeyButton, rsaButton])
+        let stackView = UIStackView(arrangedSubviews: [keccakSetupButton, keccakZkeyButton, rsaButton, kimchiButton])
         stackView.axis = .vertical
         stackView.spacing = 20
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -78,14 +81,9 @@ class ViewController: UIViewController {
         let rsaVC = RSAViewController()
         navigationController?.pushViewController(rsaVC, animated: true)
     }
+
+    @objc func openKimchi() {
+        let kimchiVC = KimchiViewController()
+        navigationController?.pushViewController(kimchiVC, animated: true)
+    }
 }
-
-//        // Make buttons bigger
-//        proveButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
-//        verifyButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
-
-//        NSLayoutConstraint.activate([
-//            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-//            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-//            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20)
-//        ])

--- a/mopro-ios/MoproKit/Example/MoproKit/ViewController.swift
+++ b/mopro-ios/MoproKit/Example/MoproKit/ViewController.swift
@@ -9,7 +9,6 @@
 import UIKit
 import MoproKit
 
-
 // Main ViewController
 class ViewController: UIViewController {
 

--- a/mopro-ios/MoproKit/Include/moproFFI.h
+++ b/mopro-ios/MoproKit/Include/moproFFI.h
@@ -88,6 +88,9 @@ void uniffi_mopro_fn_func_initialize_mopro(RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_mopro_fn_func_generate_proof2(RustBuffer circuit_inputs, RustCallStatus *_Nonnull out_status
 );
+void uniffi_mopro_fn_func_kimchi_bench(RustCallStatus *_Nonnull out_status
+    
+);
 RustBuffer ffi_mopro_rustbuffer_alloc(int32_t size, RustCallStatus *_Nonnull out_status
 );
 RustBuffer ffi_mopro_rustbuffer_from_bytes(ForeignBytes bytes, RustCallStatus *_Nonnull out_status
@@ -106,6 +109,9 @@ uint16_t uniffi_mopro_checksum_func_initialize_mopro(void
     
 );
 uint16_t uniffi_mopro_checksum_func_generate_proof2(void
+    
+);
+uint16_t uniffi_mopro_checksum_func_kimchi_bench(void
     
 );
 uint16_t uniffi_mopro_checksum_method_moprocircom_setup(void

--- a/mopro-ios/MoproKit/Include/moproFFI.h
+++ b/mopro-ios/MoproKit/Include/moproFFI.h
@@ -64,6 +64,7 @@ typedef void (*UniFfiFutureCallbackUInt8)(const void * _Nonnull, uint8_t, RustCa
 typedef void (*UniFfiFutureCallbackInt8)(const void * _Nonnull, int8_t, RustCallStatus);
 typedef void (*UniFfiFutureCallbackUInt32)(const void * _Nonnull, uint32_t, RustCallStatus);
 typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
+typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
 typedef void (*UniFfiFutureCallbackRustBuffer)(const void * _Nonnull, RustBuffer, RustCallStatus);
 
 // Scaffolding functions
@@ -77,6 +78,15 @@ RustBuffer uniffi_mopro_fn_method_moprocircom_setup(void*_Nonnull ptr, RustBuffe
 RustBuffer uniffi_mopro_fn_method_moprocircom_generate_proof(void*_Nonnull ptr, RustBuffer circuit_inputs, RustCallStatus *_Nonnull out_status
 );
 int8_t uniffi_mopro_fn_method_moprocircom_verify_proof(void*_Nonnull ptr, RustBuffer proof, RustBuffer public_input, RustCallStatus *_Nonnull out_status
+);
+void uniffi_mopro_fn_free_moprokimchi(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_mopro_fn_constructor_moprokimchi_new(RustCallStatus *_Nonnull out_status
+    
+);
+RustBuffer uniffi_mopro_fn_method_moprokimchi_create_proof(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+int8_t uniffi_mopro_fn_method_moprokimchi_verify_proof(void*_Nonnull ptr, RustBuffer proof, RustCallStatus *_Nonnull out_status
 );
 uint32_t uniffi_mopro_fn_func_add(uint32_t a, uint32_t b, RustCallStatus *_Nonnull out_status
 );
@@ -123,7 +133,16 @@ uint16_t uniffi_mopro_checksum_method_moprocircom_generate_proof(void
 uint16_t uniffi_mopro_checksum_method_moprocircom_verify_proof(void
     
 );
+uint16_t uniffi_mopro_checksum_method_moprokimchi_create_proof(void
+    
+);
+uint16_t uniffi_mopro_checksum_method_moprokimchi_verify_proof(void
+    
+);
 uint16_t uniffi_mopro_checksum_constructor_moprocircom_new(void
+    
+);
+uint16_t uniffi_mopro_checksum_constructor_moprokimchi_new(void
     
 );
 uint32_t ffi_mopro_uniffi_contract_version(void


### PR DESCRIPTION
Super hacky initial Kimchi PoC. Wraps some bench tests in Kimchi, https://github.com/o1-labs/proof-systems/blob/master/kimchi/src/bench.rs#L125-L141 Takes some shortcuts with serialization/error handling etc.

Screenshot from iPhone 14:

![IMG_8359](https://github.com/oskarth/mopro/assets/1552237/9b57c935-b96b-4683-9d8a-ed8d050f0c94)

Minor modifications upstream here https://github.com/oskarth/proof-systems