### PR TITLE
feat: load zkey from a file path, add file downloader in swift

### DIFF
--- a/config-example-android.toml
+++ b/config-example-android.toml
@@ -9,7 +9,7 @@ device_type = "arm64" # Options: x86_64, simulator, device, arm, arm64
 
 # debug is for Rust library to be in debug mode and release for release mode
 # We recommend release mode by default for performance
-build_mode = "debug" # Options: debug, release
+build_mode = "release" # Options: debug, release
 
 [circuit]
 dir = "examples/circom/keccak256" # Directory of the circuit

--- a/mopro-core/src/lib.rs
+++ b/mopro-core/src/lib.rs
@@ -5,4 +5,6 @@ use thiserror::Error;
 pub enum MoproError {
     #[error("CircomError: {0}")]
     CircomError(String),
+    #[error("IoError: {0}")]
+    IoError(String),
 }

--- a/mopro-ffi/src/lib.rs
+++ b/mopro-ffi/src/lib.rs
@@ -66,6 +66,16 @@ impl From<mopro_core::MoproError> for FFIError {
     }
 }
 
+pub struct MoproCircom2 {
+    state: RwLock<circom::CircomState2>,
+}
+
+impl Default for MoproCircom2 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub struct MoproCircom {
     state: RwLock<circom::CircomState>,
 }
@@ -130,10 +140,15 @@ pub fn generate_proof2(
     })
 }
 
-pub fn verify_proof2(zkey_path: String,proof: Vec<u8>, public_input: Vec<u8>) -> Result<bool, MoproError> {
+pub fn verify_proof2(
+    zkey_path: String,
+    proof: Vec<u8>,
+    public_input: Vec<u8>,
+) -> Result<bool, MoproError> {
     let deserialized_proof = circom::serialization::deserialize_proof(proof);
     let deserialized_public_input = circom::serialization::deserialize_inputs(public_input);
-    let is_valid = circom::verify_proof2(&zkey_path, deserialized_proof, deserialized_public_input)?;
+    let is_valid =
+        circom::verify_proof2(&zkey_path, deserialized_proof, deserialized_public_input)?;
     Ok(is_valid)
 }
 
@@ -180,6 +195,57 @@ impl MoproCircom {
         Ok(SetupResult {
             provingKey: circom::serialization::serialize_proving_key(&pk),
         })
+    }
+
+    //             inputs: circom::serialization::serialize_inputs(&inputs),
+
+    pub fn generate_proof(
+        &self,
+        inputs: HashMap<String, Vec<String>>,
+    ) -> Result<GenerateProofResult, MoproError> {
+        let mut state_guard = self.state.write().unwrap();
+
+        // Convert inputs to BigInt
+        let bigint_inputs = inputs
+            .into_iter()
+            .map(|(k, v)| {
+                (
+                    k,
+                    v.into_iter()
+                        .map(|i| BigInt::from_str(&i).unwrap())
+                        .collect(),
+                )
+            })
+            .collect();
+
+        let (proof, inputs) = state_guard.generate_proof(bigint_inputs)?;
+
+        Ok(GenerateProofResult {
+            proof: circom::serialization::serialize_proof(&proof),
+            inputs: circom::serialization::serialize_inputs(&inputs),
+        })
+    }
+
+    pub fn verify_proof(&self, proof: Vec<u8>, public_input: Vec<u8>) -> Result<bool, MoproError> {
+        let state_guard = self.state.read().unwrap();
+        let deserialized_proof = circom::serialization::deserialize_proof(proof);
+        let deserialized_public_input = circom::serialization::deserialize_inputs(public_input);
+        let is_valid = state_guard.verify_proof(deserialized_proof, deserialized_public_input)?;
+        Ok(is_valid)
+    }
+}
+
+impl MoproCircom2 {
+    pub fn new() -> Self {
+        Self {
+            state: RwLock::new(circom::CircomState2::new()),
+        }
+    }
+
+    pub fn initialize(&self, zkey_path: String) -> Result<(), MoproError> {
+        let mut state_guard = self.state.write().unwrap();
+        state_guard.initialize(zkey_path.as_str())?;
+        Ok(())
     }
 
     //             inputs: circom::serialization::serialize_inputs(&inputs),

--- a/mopro-ffi/src/lib.rs
+++ b/mopro-ffi/src/lib.rs
@@ -104,6 +104,7 @@ pub fn initialize_mopro_dylib(dylib_path: String) -> Result<(), MoproError> {
 }
 
 pub fn generate_proof2(
+    zkey_path: String,
     inputs: HashMap<String, Vec<String>>,
 ) -> Result<GenerateProofResult, MoproError> {
     // Convert inputs to BigInt
@@ -119,7 +120,7 @@ pub fn generate_proof2(
         })
         .collect();
 
-    let (proof, inputs) = circom::generate_proof2(bigint_inputs)?;
+    let (proof, inputs) = circom::generate_proof2(&zkey_path, bigint_inputs)?;
 
     let serialized_proof = circom::serialization::serialize_proof(&proof);
     let serialized_inputs = circom::serialization::serialize_inputs(&inputs);
@@ -129,10 +130,10 @@ pub fn generate_proof2(
     })
 }
 
-pub fn verify_proof2(proof: Vec<u8>, public_input: Vec<u8>) -> Result<bool, MoproError> {
+pub fn verify_proof2(zkey_path: String,proof: Vec<u8>, public_input: Vec<u8>) -> Result<bool, MoproError> {
     let deserialized_proof = circom::serialization::deserialize_proof(proof);
     let deserialized_public_input = circom::serialization::deserialize_inputs(public_input);
-    let is_valid = circom::verify_proof2(deserialized_proof, deserialized_public_input)?;
+    let is_valid = circom::verify_proof2(&zkey_path, deserialized_proof, deserialized_public_input)?;
     Ok(is_valid)
 }
 

--- a/mopro-ffi/src/mopro.udl
+++ b/mopro-ffi/src/mopro.udl
@@ -72,3 +72,17 @@ interface MoproCircom {
   [Throws=MoproError]
   boolean verify_proof(bytes proof, bytes public_input);
 };
+
+interface MoproCircom2 {
+  constructor();
+
+  [Throws=MoproError]
+  void initialize(string zkey_path);
+
+  [Throws=MoproError]
+  GenerateProofResult generate_proof(record<string, sequence<string>> circuit_inputs);
+
+  [Throws=MoproError]
+  boolean verify_proof(bytes proof, bytes public_input);
+};
+

--- a/mopro-ffi/src/mopro.udl
+++ b/mopro-ffi/src/mopro.udl
@@ -9,10 +9,10 @@ namespace mopro {
   void initialize_mopro_dylib(string dylib_path);
 
   [Throws=MoproError]
-  GenerateProofResult generate_proof2(record<string, sequence<string>> circuit_inputs);
+  GenerateProofResult generate_proof2(string zkey_path, record<string, sequence<string>> circuit_inputs);
 
   [Throws=MoproError]
-  boolean verify_proof2(bytes proof, bytes public_input);
+  boolean verify_proof2(string zkey_path, bytes proof, bytes public_input);
 
   [Throws=MoproError]
   BenchmarkResult run_msm_benchmark(u32? num_msm);
@@ -57,6 +57,7 @@ dictionary ProofCalldata {
 [Error]
 enum MoproError {
   "CircomError",
+  "IoError",
 };
 
 interface MoproCircom {

--- a/mopro-ffi/tests/bindings/test_mopro_keccak.swift
+++ b/mopro-ffi/tests/bindings/test_mopro_keccak.swift
@@ -1,10 +1,11 @@
 import mopro
 import Foundation
 
-let moproCircom = MoproCircom()
+let moproCircom = MoproCircom2()
 
 let wasmPath = "./../../../../mopro-core/examples/circom/keccak256/target/keccak256_256_test_js/keccak256_256_test.wasm"
 let r1csPath = "./../../../../mopro-core/examples/circom/keccak256/target/keccak256_256_test.r1cs"
+let zkeyPath = "./../../../../mopro-core/examples/circom/keccak256/target/keccak256_256_test_final.arkzkey"
 
 // Helper function to convert bytes to bits
 func bytesToBits(bytes: [UInt8]) -> [String] {
@@ -45,8 +46,8 @@ func serializeOutputs(_ stringArray: [String]) -> [UInt8] {
 
 do {
     // Setup
-    let setupResult = try moproCircom.setup(wasmPath: wasmPath, r1csPath: r1csPath)
-    assert(!setupResult.provingKey.isEmpty, "Proving key should not be empty")
+    let setupResult = try moproCircom.initialize(zkeyPath: zkeyPath)
+    // assert(!setupResult.provingKey.isEmpty, "Proving key should not be empty")
 
     // Prepare inputs
     let inputVec: [UInt8] = [

--- a/mopro-ffi/tests/bindings/test_mopro_keccak2.swift
+++ b/mopro-ffi/tests/bindings/test_mopro_keccak2.swift
@@ -7,6 +7,7 @@ import mopro
 
 // let wasmPath = "./../../../../mopro-core/examples/circom/keccak256/target/keccak256_256_test_js/keccak256_256_test.wasm"
 // let r1csPath = "./../../../../mopro-core/examples/circom/keccak256/target/keccak256_256_test.r1cs"
+let zkeyPath = "./../../../../mopro-core/examples/circom/keccak256/target/keccak256_256_test_final.arkzkey"
 
 // Helper function to convert bytes to bits
 func bytesToBits(bytes: [UInt8]) -> [String] {
@@ -68,7 +69,7 @@ do {
   let expectedOutput: [UInt8] = serializeOutputs(outputBits)
 
   // // Generate Proof
-  let generateProofResult = try generateProof2(circuitInputs: inputs)
+  let generateProofResult = try generateProof2(zkeyPath: zkeyPath, circuitInputs: inputs)
   // let generateProofResult = try moproCircom.generateProof(circuitInputs: inputs)
   assert(!generateProofResult.proof.isEmpty, "Proof should not be empty")
 
@@ -76,6 +77,7 @@ do {
   assert(Data(expectedOutput) == generateProofResult.inputs, "Circuit outputs mismatch the expected outputs")
 
   let isValid = try verifyProof2(
+    zkeyPath: zkeyPath,
     proof: generateProofResult.proof, publicInput: generateProofResult.inputs)
   assert(isValid, "Proof verification should succeed")
 

--- a/mopro-ios/MoproKit/Bindings/mopro.swift
+++ b/mopro-ios/MoproKit/Bindings/mopro.swift
@@ -505,6 +505,110 @@ public func FfiConverterTypeMoproCircom_lower(_ value: MoproCircom) -> UnsafeMut
 }
 
 
+public protocol MoproCircom2Protocol {
+    func generateProof(circuitInputs: [String: [String]])  throws -> GenerateProofResult
+    func initialize(zkeyPath: String)  throws
+    func verifyProof(proof: Data, publicInput: Data)  throws -> Bool
+    
+}
+
+public class MoproCircom2: MoproCircom2Protocol {
+    fileprivate let pointer: UnsafeMutableRawPointer
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+    public convenience init()  {
+        self.init(unsafeFromRawPointer: try! rustCall() {
+    uniffi_mopro_ffi_fn_constructor_moprocircom2_new($0)
+})
+    }
+
+    deinit {
+        try! rustCall { uniffi_mopro_ffi_fn_free_moprocircom2(pointer, $0) }
+    }
+
+    
+
+    
+    
+
+    public func generateProof(circuitInputs: [String: [String]]) throws -> GenerateProofResult {
+        return try  FfiConverterTypeGenerateProofResult.lift(
+            try 
+    rustCallWithError(FfiConverterTypeMoproError.lift) {
+    uniffi_mopro_ffi_fn_method_moprocircom2_generate_proof(self.pointer, 
+        FfiConverterDictionaryStringSequenceString.lower(circuitInputs),$0
+    )
+}
+        )
+    }
+
+    public func initialize(zkeyPath: String) throws {
+        try 
+    rustCallWithError(FfiConverterTypeMoproError.lift) {
+    uniffi_mopro_ffi_fn_method_moprocircom2_initialize(self.pointer, 
+        FfiConverterString.lower(zkeyPath),$0
+    )
+}
+    }
+
+    public func verifyProof(proof: Data, publicInput: Data) throws -> Bool {
+        return try  FfiConverterBool.lift(
+            try 
+    rustCallWithError(FfiConverterTypeMoproError.lift) {
+    uniffi_mopro_ffi_fn_method_moprocircom2_verify_proof(self.pointer, 
+        FfiConverterData.lower(proof),
+        FfiConverterData.lower(publicInput),$0
+    )
+}
+        )
+    }
+}
+
+public struct FfiConverterTypeMoproCircom2: FfiConverter {
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = MoproCircom2
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MoproCircom2 {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if (ptr == nil) {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: MoproCircom2, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> MoproCircom2 {
+        return MoproCircom2(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: MoproCircom2) -> UnsafeMutableRawPointer {
+        return value.pointer
+    }
+}
+
+
+public func FfiConverterTypeMoproCircom2_lift(_ pointer: UnsafeMutableRawPointer) throws -> MoproCircom2 {
+    return try FfiConverterTypeMoproCircom2.lift(pointer)
+}
+
+public func FfiConverterTypeMoproCircom2_lower(_ value: MoproCircom2) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeMoproCircom2.lower(value)
+}
+
+
 public struct BenchmarkResult {
     public var numMsm: UInt32
     public var avgProcessingTime: Double
@@ -1111,7 +1215,19 @@ private var initializationResult: InitializationResult {
     if (uniffi_mopro_ffi_checksum_method_moprocircom_verify_proof() != 61522) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_mopro_ffi_checksum_method_moprocircom2_generate_proof() != 28879) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mopro_ffi_checksum_method_moprocircom2_initialize() != 11891) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mopro_ffi_checksum_method_moprocircom2_verify_proof() != 626) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_mopro_ffi_checksum_constructor_moprocircom_new() != 42205) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mopro_ffi_checksum_constructor_moprocircom2_new() != 20845) {
         return InitializationResult.apiChecksumMismatch
     }
 

--- a/mopro-ios/MoproKit/Bindings/mopro.swift
+++ b/mopro-ios/MoproKit/Bindings/mopro.swift
@@ -857,6 +857,9 @@ public enum MoproError {
     // Simple error enums only carry a message
     case CircomError(message: String)
     
+    // Simple error enums only carry a message
+    case IoError(message: String)
+    
 
     fileprivate static func uniffiErrorHandler(_ error: RustBuffer) throws -> Error {
         return try FfiConverterTypeMoproError.lift(error)
@@ -878,6 +881,10 @@ public struct FfiConverterTypeMoproError: FfiConverterRustBuffer {
             message: try FfiConverterString.read(from: &buf)
         )
         
+        case 2: return .IoError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -891,6 +898,8 @@ public struct FfiConverterTypeMoproError: FfiConverterRustBuffer {
         
         case .CircomError(_ /* message is ignored*/):
             writeInt(&buf, Int32(1))
+        case .IoError(_ /* message is ignored*/):
+            writeInt(&buf, Int32(2))
 
         
         }
@@ -978,10 +987,11 @@ public func add(a: UInt32, b: UInt32)  -> UInt32 {
     )
 }
 
-public func generateProof2(circuitInputs: [String: [String]]) throws -> GenerateProofResult {
+public func generateProof2(zkeyPath: String, circuitInputs: [String: [String]]) throws -> GenerateProofResult {
     return try  FfiConverterTypeGenerateProofResult.lift(
         try rustCallWithError(FfiConverterTypeMoproError.lift) {
     uniffi_mopro_ffi_fn_func_generate_proof2(
+        FfiConverterString.lower(zkeyPath),
         FfiConverterDictionaryStringSequenceString.lower(circuitInputs),$0)
 }
     )
@@ -1039,10 +1049,11 @@ public func toEthereumProof(proof: Data)  -> ProofCalldata {
     )
 }
 
-public func verifyProof2(proof: Data, publicInput: Data) throws -> Bool {
+public func verifyProof2(zkeyPath: String, proof: Data, publicInput: Data) throws -> Bool {
     return try  FfiConverterBool.lift(
         try rustCallWithError(FfiConverterTypeMoproError.lift) {
     uniffi_mopro_ffi_fn_func_verify_proof2(
+        FfiConverterString.lower(zkeyPath),
         FfiConverterData.lower(proof),
         FfiConverterData.lower(publicInput),$0)
 }
@@ -1067,7 +1078,7 @@ private var initializationResult: InitializationResult {
     if (uniffi_mopro_ffi_checksum_func_add() != 8411) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mopro_ffi_checksum_func_generate_proof2() != 40187) {
+    if (uniffi_mopro_ffi_checksum_func_generate_proof2() != 37475) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mopro_ffi_checksum_func_hello() != 46136) {
@@ -1088,7 +1099,7 @@ private var initializationResult: InitializationResult {
     if (uniffi_mopro_ffi_checksum_func_to_ethereum_proof() != 60110) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mopro_ffi_checksum_func_verify_proof2() != 37192) {
+    if (uniffi_mopro_ffi_checksum_func_verify_proof2() != 30573) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mopro_ffi_checksum_method_moprocircom_generate_proof() != 64602) {

--- a/mopro-ios/MoproKit/Example/MoproKit.xcodeproj/project.pbxproj
+++ b/mopro-ios/MoproKit/Example/MoproKit.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		2A418AB02AF4B1200004B747 /* CircomUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A418AAF2AF4B1200004B747 /* CircomUITests.swift */; };
 		2A6E5BAF2AF499460052A601 /* CircomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A6E5BAE2AF499460052A601 /* CircomTests.swift */; };
+		2AAD38B22B6CC318004F37BB /* FileDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AAD38B12B6CC318004F37BB /* FileDownloader.swift */; };
 		4384FD09A96F702A375841EE /* Pods_MoproKit_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78B0F9CBE5DD22576996A993 /* Pods_MoproKit_Tests.framework */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
@@ -46,6 +47,7 @@
 		1E5E014D70B48C9A59F14658 /* Pods-MoproKit_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MoproKit_Example.release.xcconfig"; path = "Target Support Files/Pods-MoproKit_Example/Pods-MoproKit_Example.release.xcconfig"; sourceTree = "<group>"; };
 		2A418AAF2AF4B1200004B747 /* CircomUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircomUITests.swift; sourceTree = "<group>"; };
 		2A6E5BAE2AF499460052A601 /* CircomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircomTests.swift; sourceTree = "<group>"; };
+		2AAD38B12B6CC318004F37BB /* FileDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDownloader.swift; sourceTree = "<group>"; };
 		47F8ADB0AC4168C6E874818D /* MoproKit.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = MoproKit.podspec; path = ../MoproKit.podspec; sourceTree = "<group>"; };
 		5DAF212A114DFA0C9F4282B2 /* Pods-MoproKit_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MoproKit_Tests.debug.xcconfig"; path = "Target Support Files/Pods-MoproKit_Tests/Pods-MoproKit_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* MoproKit_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MoproKit_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -127,6 +129,7 @@
 		607FACD21AFB9204008FA782 /* Example for MoproKit */ = {
 			isa = PBXGroup;
 			children = (
+				2AAD38B12B6CC318004F37BB /* FileDownloader.swift */,
 				CEB804572AFF81BF0063F091 /* RSAViewController.swift */,
 				E69338632AFFDB1A00B80312 /* AnonAadhaarViewController.swift */,
 				CEB804552AFF81AF0063F091 /* KeccakZkeyViewController.swift */,
@@ -408,6 +411,7 @@
 			files = (
 				CEB804582AFF81BF0063F091 /* RSAViewController.swift in Sources */,
 				CEB804562AFF81AF0063F091 /* KeccakZkeyViewController.swift in Sources */,
+				2AAD38B22B6CC318004F37BB /* FileDownloader.swift in Sources */,
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
 				CEB804502AFF81960063F091 /* KeccakSetupViewController.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,

--- a/mopro-ios/MoproKit/Example/MoproKit.xcodeproj/project.pbxproj
+++ b/mopro-ios/MoproKit/Example/MoproKit.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		2A418AB02AF4B1200004B747 /* CircomUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A418AAF2AF4B1200004B747 /* CircomUITests.swift */; };
 		2A6E5BAF2AF499460052A601 /* CircomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A6E5BAE2AF499460052A601 /* CircomTests.swift */; };
 		2AAD38B22B6CC318004F37BB /* FileDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AAD38B12B6CC318004F37BB /* FileDownloader.swift */; };
+		2ABABA752B709BD3009EBC9E /* keccak256_256_test_final.arkzkey in Resources */ = {isa = PBXBuildFile; fileRef = 2ABABA742B709BD3009EBC9E /* keccak256_256_test_final.arkzkey */; };
+		2ABABA762B709BD3009EBC9E /* keccak256_256_test_final.arkzkey in Resources */ = {isa = PBXBuildFile; fileRef = 2ABABA742B709BD3009EBC9E /* keccak256_256_test_final.arkzkey */; };
 		4384FD09A96F702A375841EE /* Pods_MoproKit_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78B0F9CBE5DD22576996A993 /* Pods_MoproKit_Tests.framework */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
@@ -48,6 +50,7 @@
 		2A418AAF2AF4B1200004B747 /* CircomUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircomUITests.swift; sourceTree = "<group>"; };
 		2A6E5BAE2AF499460052A601 /* CircomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircomTests.swift; sourceTree = "<group>"; };
 		2AAD38B12B6CC318004F37BB /* FileDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDownloader.swift; sourceTree = "<group>"; };
+		2ABABA742B709BD3009EBC9E /* keccak256_256_test_final.arkzkey */ = {isa = PBXFileReference; lastKnownFileType = file; name = keccak256_256_test_final.arkzkey; path = "../../../../../mopro-core/examples/circom/keccak256/target/keccak256_256_test_final.arkzkey"; sourceTree = "<group>"; };
 		47F8ADB0AC4168C6E874818D /* MoproKit.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = MoproKit.podspec; path = ../MoproKit.podspec; sourceTree = "<group>"; };
 		5DAF212A114DFA0C9F4282B2 /* Pods-MoproKit_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MoproKit_Tests.debug.xcconfig"; path = "Target Support Files/Pods-MoproKit_Tests/Pods-MoproKit_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* MoproKit_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MoproKit_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -185,6 +188,7 @@
 		CEA2D1282AB9681E00F292D2 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				2ABABA742B709BD3009EBC9E /* keccak256_256_test_final.arkzkey */,
 				CE2C1B8B2AFFCC5E002AF8BC /* main.wasm */,
 				CE5A5C082AD43A860074539D /* keccak256_256_test.r1cs */,
 				CE5A5C052AD43A790074539D /* keccak256_256_test.wasm */,
@@ -296,6 +300,7 @@
 			files = (
 				CEA2D1322AB96AB500F292D2 /* multiplier2.r1cs in Resources */,
 				607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */,
+				2ABABA752B709BD3009EBC9E /* keccak256_256_test_final.arkzkey in Resources */,
 				607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */,
 				CE5A5C062AD43A790074539D /* keccak256_256_test.wasm in Resources */,
 				CE2C1B8C2AFFCC5E002AF8BC /* main.wasm in Resources */,
@@ -311,6 +316,7 @@
 			files = (
 				CE5A5C0A2AD43A860074539D /* keccak256_256_test.r1cs in Resources */,
 				CE5A5C072AD43A790074539D /* keccak256_256_test.wasm in Resources */,
+				2ABABA762B709BD3009EBC9E /* keccak256_256_test_final.arkzkey in Resources */,
 				CE2C1B8D2AFFCC5E002AF8BC /* main.wasm in Resources */,
 				CEA2D1332AB96AB500F292D2 /* multiplier2.r1cs in Resources */,
 				CEA2D1302AB96A7A00F292D2 /* multiplier2.wasm in Resources */,

--- a/mopro-ios/MoproKit/Example/MoproKit/FileDownloader.swift
+++ b/mopro-ios/MoproKit/Example/MoproKit/FileDownloader.swift
@@ -1,0 +1,95 @@
+//
+//  FileDownloader.swift
+//  MoproKit
+//
+//  Copyright © 2024 CocoaPods. All rights reserved.
+//
+
+import Foundation
+
+class FileDownloader {
+
+    static func loadFileSync(url: URL, completion: @escaping (String?, Error?) -> Void)
+    {
+        let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+
+        let destinationUrl = documentsUrl.appendingPathComponent(url.lastPathComponent)
+
+        if FileManager().fileExists(atPath: destinationUrl.path)
+        {
+            print("File already exists [\(destinationUrl.path)]")
+            completion(destinationUrl.path, nil)
+        }
+        else if let dataFromURL = NSData(contentsOf: url)
+        {
+            if dataFromURL.write(to: destinationUrl, atomically: true)
+            {
+                print("file saved [\(destinationUrl.path)]")
+                completion(destinationUrl.path, nil)
+            }
+            else
+            {
+                print("error saving file")
+                let error = NSError(domain:"Error saving file", code:1001, userInfo:nil)
+                completion(destinationUrl.path, error)
+            }
+        }
+        else
+        {
+            let error = NSError(domain:"Error downloading file", code:1002, userInfo:nil)
+            completion(destinationUrl.path, error)
+        }
+    }
+
+    static func loadFileAsync(url: URL, completion: @escaping (String?, Error?) -> Void)
+    {
+        let documentsUrl =  FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+
+        let destinationUrl = documentsUrl.appendingPathComponent(url.lastPathComponent)
+
+        if FileManager().fileExists(atPath: destinationUrl.path)
+        {
+            print("File already exists [\(destinationUrl.path)]")
+            completion(destinationUrl.path, nil)
+        }
+        else
+        {
+            let session = URLSession(configuration: URLSessionConfiguration.default, delegate: nil, delegateQueue: nil)
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            let task = session.dataTask(with: request, completionHandler:
+            {
+                data, response, error in
+                if error == nil
+                {
+                    if let response = response as? HTTPURLResponse
+                    {
+                        if response.statusCode == 200
+                        {
+                            if let data = data
+                            {
+                                if let _ = try? data.write(to: destinationUrl, options: Data.WritingOptions.atomic)
+                                {
+                                    completion(destinationUrl.path, error)
+                                }
+                                else
+                                {
+                                    completion(destinationUrl.path, error)
+                                }
+                            }
+                            else
+                            {
+                                completion(destinationUrl.path, error)
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    completion(destinationUrl.path, error)
+                }
+            })
+            task.resume()
+        }
+    }
+}

--- a/mopro-ios/MoproKit/Example/MoproKit/KeccakSetupViewController.swift
+++ b/mopro-ios/MoproKit/Example/MoproKit/KeccakSetupViewController.swift
@@ -10,13 +10,15 @@ import UIKit
 import MoproKit
 
 class KeccakSetupViewController: UIViewController {
+    
+    let url = URL(string: "https://mopro.vivianjeng.xyz/keccak256_256_test_final.arkzkey")
 
     var setupButton = UIButton(type: .system)
     var proveButton = UIButton(type: .system)
     var verifyButton = UIButton(type: .system)
     var textView = UITextView()
 
-    let moproCircom = MoproKit.MoproCircom()
+    let moproCircom = MoproKit.MoproCircom2()
     var setupResult: SetupResult?
     var generatedProof: Data?
     var publicInputs: Data?
@@ -81,14 +83,19 @@ class KeccakSetupViewController: UIViewController {
     @objc func runSetupAction() {
         // Logic for setup
         if let wasmPath = Bundle.main.path(forResource: "keccak256_256_test", ofType: "wasm"),
-            let r1csPath = Bundle.main.path(forResource: "keccak256_256_test", ofType: "r1cs") {
+            let r1csPath = Bundle.main.path(forResource: "keccak256_256_test", ofType: "r1cs"),
+            let zkeyPath = Bundle.main.path(forResource: "keccak256_256_test_final", ofType: "arkzkey"){
 
        // Multiplier example
        // if let wasmPath = Bundle.main.path(forResource: "multiplier2", ofType: "wasm"),
        //    let r1csPath = Bundle.main.path(forResource: "multiplier2", ofType: "r1cs") {
 
            do {
-               setupResult = try moproCircom.setup(wasmPath: wasmPath, r1csPath: r1csPath)
+               // Ark zkey url
+               let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+               let destinationUrl = documentsUrl.appendingPathComponent((url!).lastPathComponent)
+               
+               try moproCircom.initialize(zkeyPath: destinationUrl.path)
                proveButton.isEnabled = true // Enable the Prove button upon successful setup
            } catch let error as MoproError {
                print("MoproError: \(error)")
@@ -102,10 +109,10 @@ class KeccakSetupViewController: UIViewController {
 
     @objc func runProveAction() {
         // Logic for prove
-       guard let setupResult = setupResult else {
-           print("Setup is not completed yet.")
-           return
-        }
+       // guard let setupResult = setupResult else {
+        //   print("Setup is not completed yet.")
+        //   return
+        // }
         do {
             // Prepare inputs
             let inputVec: [UInt8] = [
@@ -149,8 +156,8 @@ class KeccakSetupViewController: UIViewController {
 
     @objc func runVerifyAction() {
         // Logic for verify
-        guard let setupResult = setupResult,
-                let proof = generatedProof,
+        //guard let setupResult = setupResult,
+        guard let proof = generatedProof,
                 let publicInputs = publicInputs else {
             print("Setup is not completed or proof has not been generated yet.")
             return

--- a/mopro-ios/MoproKit/Example/MoproKit/KeccakZkeyViewController.swift
+++ b/mopro-ios/MoproKit/Example/MoproKit/KeccakZkeyViewController.swift
@@ -9,8 +9,12 @@
 import UIKit
 import MoproKit
 
+
 class KeccakZkeyViewController: UIViewController {
 
+    let url = URL(string: "https://mopro.vivianjeng.xyz/keccak256_256_test_final.arkzkey")
+    
+    var downloadButton = UIButton(type: .system)
     var initButton = UIButton(type: .system)
     var proveButton = UIButton(type: .system)
     var verifyButton = UIButton(type: .system)
@@ -37,26 +41,30 @@ class KeccakZkeyViewController: UIViewController {
     }
 
     func setupUI() {
+        downloadButton.setTitle("Download ZKey", for: .normal)
         initButton.setTitle("Init", for: .normal)
         proveButton.setTitle("Prove", for: .normal)
         verifyButton.setTitle("Verify", for: .normal)
 
         // Uncomment once init separate
         //proveButton.isEnabled = false
+        downloadButton.isEnabled = true
         proveButton.isEnabled = true
         verifyButton.isEnabled = false
         textView.isEditable = false
 
         // Setup actions for buttons
+        downloadButton.addTarget(self, action: #selector(runDownloadAction), for: .touchUpInside)
         initButton.addTarget(self, action: #selector(runInitAction), for: .touchUpInside)
         proveButton.addTarget(self, action: #selector(runProveAction), for: .touchUpInside)
         verifyButton.addTarget(self, action: #selector(runVerifyAction), for: .touchUpInside)
 
+       downloadButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
        initButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
        proveButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
        verifyButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
 
-        let stackView = UIStackView(arrangedSubviews: [initButton, proveButton, verifyButton, textView])
+        let stackView = UIStackView(arrangedSubviews: [downloadButton, initButton, proveButton, verifyButton, textView])
         stackView.axis = .vertical
         stackView.spacing = 10
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -116,9 +124,13 @@ class KeccakZkeyViewController: UIViewController {
 
             // Record start time
             let start = CFAbsoluteTimeGetCurrent()
+            
+            // Ark zkey url
+            let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            let destinationUrl = documentsUrl.appendingPathComponent((url!).lastPathComponent)
 
             // Generate Proof
-            let generateProofResult = try generateProof2(circuitInputs: inputs)
+            let generateProofResult = try generateProof2(zkeyPath: destinationUrl.path, circuitInputs: inputs)
             assert(!generateProofResult.proof.isEmpty, "Proof should not be empty")
             //assert(Data(expectedOutput) == generateProofResult.inputs, "Circuit outputs mismatch the expected outputs")
 
@@ -143,5 +155,19 @@ class KeccakZkeyViewController: UIViewController {
 
     @objc func runVerifyAction() {
         // Logic for verify
+        
+    }
+    
+    @objc func runDownloadAction() {
+        do {
+            let start = CFAbsoluteTimeGetCurrent()
+            FileDownloader.loadFileAsync(url: url!) { (path, error) in
+                print("Ark key File downloaded to : \(path!)")
+            }
+            let end = CFAbsoluteTimeGetCurrent()
+            print("Download ark key took:", end - start)
+        } catch {
+            print("Unexpected error: \(error)")
+        }
     }
 }

--- a/mopro-ios/MoproKit/Example/MoproKit/RSAViewController.swift
+++ b/mopro-ios/MoproKit/Example/MoproKit/RSAViewController.swift
@@ -10,7 +10,10 @@ import UIKit
 import MoproKit
 
 class RSAViewController: UIViewController {
+    
+    let url = URL(string: "https://mopro.vivianjeng.xyz/main_final.arkzkey")
 
+    var downloadButton = UIButton(type: .system)
     var initButton = UIButton(type: .system)
     var proveButton = UIButton(type: .system)
     var verifyButton = UIButton(type: .system)
@@ -37,26 +40,30 @@ class RSAViewController: UIViewController {
     }
 
    func setupUI() {
+        downloadButton.setTitle("Download ZKey", for: .normal)
         initButton.setTitle("Init", for: .normal)
         proveButton.setTitle("Prove", for: .normal)
         verifyButton.setTitle("Verify", for: .normal)
 
         // Uncomment once init separate
         //proveButton.isEnabled = false
+        downloadButton.isEnabled = true
         proveButton.isEnabled = true
         verifyButton.isEnabled = false
         textView.isEditable = false
 
         // Setup actions for buttons
+        downloadButton.addTarget(self, action: #selector(runDownloadAction), for: .touchUpInside)
         initButton.addTarget(self, action: #selector(runInitAction), for: .touchUpInside)
         proveButton.addTarget(self, action: #selector(runProveAction), for: .touchUpInside)
         verifyButton.addTarget(self, action: #selector(runVerifyAction), for: .touchUpInside)
 
+       downloadButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
        initButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
        proveButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
        verifyButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
 
-        let stackView = UIStackView(arrangedSubviews: [initButton, proveButton, verifyButton, textView])
+        let stackView = UIStackView(arrangedSubviews: [downloadButton, initButton, proveButton, verifyButton, textView])
         stackView.axis = .vertical
         stackView.spacing = 10
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -189,9 +196,13 @@ class RSAViewController: UIViewController {
             inputs["base_message"] = base_message;
 
             let start = CFAbsoluteTimeGetCurrent()
+            
+            // Ark zkey url
+            let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            let destinationUrl = documentsUrl.appendingPathComponent((url!).lastPathComponent)
 
             // Generate Proof
-            let generateProofResult = try generateProof2(circuitInputs: inputs)
+            let generateProofResult = try generateProof2(zkeyPath: destinationUrl.path, circuitInputs: inputs)
             assert(!generateProofResult.proof.isEmpty, "Proof should not be empty")
 
             // Record end time and compute duration
@@ -220,14 +231,31 @@ class RSAViewController: UIViewController {
             print("Proof has not been generated yet.")
             return
         }
+        // Ark zkey url
+        let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let destinationUrl = documentsUrl.appendingPathComponent((url!).lastPathComponent)
+        
         do {
             // Verify Proof
-            let isValid = try verifyProof2(proof: proof, publicInput: publicInputs)
+            let isValid = try verifyProof2(zkeyPath: destinationUrl.path, proof: proof, publicInput: publicInputs)
             assert(isValid, "Proof verification should succeed")
 
             textView.text += "Proof verification succeeded.\n"
         } catch let error as MoproError {
             print("MoproError: \(error)")
+        } catch {
+            print("Unexpected error: \(error)")
+        }
+    }
+    
+    @objc func runDownloadAction() {
+        do {
+            let start = CFAbsoluteTimeGetCurrent()
+            FileDownloader.loadFileAsync(url: url!) { (path, error) in
+                print("Ark key File downloaded to : \(path!)")
+            }
+            let end = CFAbsoluteTimeGetCurrent()
+            print("Download ark key took:", end - start)
         } catch {
             print("Unexpected error: \(error)")
         }

--- a/mopro-ios/MoproKit/Include/moproFFI.h
+++ b/mopro-ios/MoproKit/Include/moproFFI.h
@@ -74,6 +74,17 @@ RustBuffer uniffi_mopro_ffi_fn_method_moprocircom_setup(void*_Nonnull ptr, RustB
 );
 int8_t uniffi_mopro_ffi_fn_method_moprocircom_verify_proof(void*_Nonnull ptr, RustBuffer proof, RustBuffer public_input, RustCallStatus *_Nonnull out_status
 );
+void uniffi_mopro_ffi_fn_free_moprocircom2(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_mopro_ffi_fn_constructor_moprocircom2_new(RustCallStatus *_Nonnull out_status
+    
+);
+RustBuffer uniffi_mopro_ffi_fn_method_moprocircom2_generate_proof(void*_Nonnull ptr, RustBuffer circuit_inputs, RustCallStatus *_Nonnull out_status
+);
+void uniffi_mopro_ffi_fn_method_moprocircom2_initialize(void*_Nonnull ptr, RustBuffer zkey_path, RustCallStatus *_Nonnull out_status
+);
+int8_t uniffi_mopro_ffi_fn_method_moprocircom2_verify_proof(void*_Nonnull ptr, RustBuffer proof, RustBuffer public_input, RustCallStatus *_Nonnull out_status
+);
 uint32_t uniffi_mopro_ffi_fn_func_add(uint32_t a, uint32_t b, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_mopro_ffi_fn_func_generate_proof2(RustBuffer zkey_path, RustBuffer circuit_inputs, RustCallStatus *_Nonnull out_status
@@ -244,7 +255,19 @@ uint16_t uniffi_mopro_ffi_checksum_method_moprocircom_setup(void
 uint16_t uniffi_mopro_ffi_checksum_method_moprocircom_verify_proof(void
     
 );
+uint16_t uniffi_mopro_ffi_checksum_method_moprocircom2_generate_proof(void
+    
+);
+uint16_t uniffi_mopro_ffi_checksum_method_moprocircom2_initialize(void
+    
+);
+uint16_t uniffi_mopro_ffi_checksum_method_moprocircom2_verify_proof(void
+    
+);
 uint16_t uniffi_mopro_ffi_checksum_constructor_moprocircom_new(void
+    
+);
+uint16_t uniffi_mopro_ffi_checksum_constructor_moprocircom2_new(void
     
 );
 uint32_t ffi_mopro_ffi_uniffi_contract_version(void

--- a/mopro-ios/MoproKit/Include/moproFFI.h
+++ b/mopro-ios/MoproKit/Include/moproFFI.h
@@ -76,7 +76,7 @@ int8_t uniffi_mopro_ffi_fn_method_moprocircom_verify_proof(void*_Nonnull ptr, Ru
 );
 uint32_t uniffi_mopro_ffi_fn_func_add(uint32_t a, uint32_t b, RustCallStatus *_Nonnull out_status
 );
-RustBuffer uniffi_mopro_ffi_fn_func_generate_proof2(RustBuffer circuit_inputs, RustCallStatus *_Nonnull out_status
+RustBuffer uniffi_mopro_ffi_fn_func_generate_proof2(RustBuffer zkey_path, RustBuffer circuit_inputs, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_mopro_ffi_fn_func_hello(RustCallStatus *_Nonnull out_status
     
@@ -92,7 +92,7 @@ RustBuffer uniffi_mopro_ffi_fn_func_to_ethereum_inputs(RustBuffer inputs, RustCa
 );
 RustBuffer uniffi_mopro_ffi_fn_func_to_ethereum_proof(RustBuffer proof, RustCallStatus *_Nonnull out_status
 );
-int8_t uniffi_mopro_ffi_fn_func_verify_proof2(RustBuffer proof, RustBuffer public_input, RustCallStatus *_Nonnull out_status
+int8_t uniffi_mopro_ffi_fn_func_verify_proof2(RustBuffer zkey_path, RustBuffer proof, RustBuffer public_input, RustCallStatus *_Nonnull out_status
 );
 RustBuffer ffi_mopro_ffi_rustbuffer_alloc(int32_t size, RustCallStatus *_Nonnull out_status
 );


### PR DESCRIPTION
Research for #65 

## TODO
- [ ] use `#[cfg(feature = "use_external_zkey")]` to control features
- [x] download and load arkzkey in `initializeMopro` (See 3.)
- [ ] download file in android and use it in proof
- [ ] benchmark different size of arkzkeys
- [ ] try on real device

1. 
load from a fixed path `e.g. "mopro-core/examples/circom/keccak256/target/keccak256_256_test_final.arkzkey"`
proving time in swift
```js
Time to deserialize proving key: 9.177727583s
Time to deserialize matrices: 70.397416ms
Initializing arkzkey took: 9.25s

Generating proof 2
Witness generation took: 423.89ms
Loading arkzkey took: 26.66ms

proof generation took: 1.36s
```
> there is no much difference between using `ARKZKEY` and `.arkzkey`
> Using `ARKZKEY` is even slightly slower than loading from a `.arkzkey` file

2. 
download from a server `e.g. "https://mopro.vivianjeng.xyz/keccak256_256_test_final.arkzkey"`
```js
Download ark key took: 0.021011948585510254

Time to deserialize proving key: 8.894824041s
Time to deserialize matrices: 26.038125ms
Initializing arkzkey took: 8.92s

Generating proof 2
Witness generation took: 410.84ms

// TODO: should be done in initialization
Time to deserialize proving key: 8.895085333s
Time to deserialize matrices: 24.071833ms
Loading arkzkey took: 8.94s
proof generation took: 979.47ms
```

3.
Init with arkzkey initialization
```js
Time to deserialize proving key: 8.930367541s
Time to deserialize matrices: 24.104291ms

Generating proof 2
Witness generation took: 429.28ms
Loading arkzkey took: 208.00ns
proof generation took: 963.43ms

Verification time 2: 3.227791ms
```