### PR TITLE
experiment(ark-zkey): Use rkyv for faster loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,7 @@ dependencies = [
  "flame",
  "flamer",
  "memmap2 0.9.4",
+ "rkyv",
 ]
 
 [[package]]

--- a/ark-zkey/Cargo.toml
+++ b/ark-zkey/Cargo.toml
@@ -14,6 +14,7 @@ color-eyre = "0.6"
 memmap2 = "0.9"
 flame = "0.2"
 flamer = "0.5"
+rkyv = "0.7.43"
 
 ark-serialize = { version = "=0.4.1", features = ["derive"] }
 ark-bn254 = { version = "=0.4.0" }


### PR DESCRIPTION
Naive experiment for https://github.com/oskarth/mopro/issues/25

Doesn't currently work due to:

```
error[E0277]: the trait bound `ProvingKey<ark_ec::models::bn::Bn<ark_bn254::Config>>: Archive` is not satisfied
  --> ark-zkey/src/lib.rs:22:30
   |
22 | #[derive(Archive, Serialize, Deserialize, Clone, Debug, PartialEq)]
   |                              ^^^^^^^^^^^ the trait `Archive` is not implemented for `ProvingKey<ark_ec::models::bn::Bn<ark_bn254::Config>>`
   |
   = help: the following other types implement trait `Archive`:
             bool
             char
             isize
             i8
             i16
             i32
             i64
             i128
           and 139 others
   = help: see issue #48214
   = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Unclear how complex it is to fix, need to either:
- Implement Archive manually for `ProvingKey<ark_ec::models::bn::Bn<ark_bn254::Config>>`
- Use a wrapper type
- Or a combination thereof

ProverKey is:

```
/// The prover key for for the Groth16 zkSNARK.
#[derive(Clone, Debug, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
pub struct ProvingKey<E: Pairing> {
    /// The underlying verification key.
    pub vk: VerifyingKey<E>,
    /// The element `beta * G` in `E::G1`.
    pub beta_g1: E::G1Affine,
    /// The element `delta * G` in `E::G1`.
    pub delta_g1: E::G1Affine,
    /// The elements `a_i * G` in `E::G1`.
    pub a_query: Vec<E::G1Affine>,
    /// The elements `b_i * G` in `E::G1`.
    pub b_g1_query: Vec<E::G1Affine>,
    /// The elements `b_i * H` in `E::G2`.
    pub b_g2_query: Vec<E::G2Affine>,
    /// The elements `h_i * G` in `E::G1`.
    pub h_query: Vec<E::G1Affine>,
    /// The elements `l_i * G` in `E::G1`.
    pub l_query: Vec<E::G1Affine>,
}
```