### PR TITLE
Reproducing Missing Bundle Executable error using framework instead of xcframework

### DIFF
--- a/scripts/cli/build_ios.sh
+++ b/scripts/cli/build_ios.sh
@@ -196,22 +196,11 @@ create_xcframework_mopro() {
 # This is done to comply with Apple's requirements for iOS apps.
 # This currently only works on real devices.
 create_xcframework_circuit() {
-    print_action "Cleaning up existing CircuitBindings XCFramework..."
-    CIRCUIT_XCFRAMEWORK_PATH="${IOS_APP_DIR}/Frameworks/CircuitBindings.xcframework"
+    print_action "Cleaning up existing CircuitBindings Framework..."
+    CIRCUIT_FRAMEWORK_PATH="${IOS_APP_DIR}/Frameworks/CircuitBindings.framework"
 
-    # Clean up any existing CircuitBindings XCFramework
-    if [ -d "$CIRCUIT_XCFRAMEWORK_PATH" ]; then
-        rm -rf "$CIRCUIT_XCFRAMEWORK_PATH"
-    fi
-
-    print_action "Creating XCFramework for CircuitBindings dylib... (${ARCHITECTURE})"
-    xcodebuild -create-xcframework \
-        -library "${TARGET_DIR}/${ARCHITECTURE}/release/${DYLIB_NAME}.dylib" \
-        -output "$CIRCUIT_XCFRAMEWORK_PATH"
-    if [ $? -ne 0 ]; then
-        echo -e "${RED}Failed to create CircuitBindings XCFramework.${DEFAULT}"
-        exit 1
-    fi
+    print_action "Creating Framework for CircuitBindings dylib... (${ARCHITECTURE})"
+    mv "${TARGET_DIR}/${ARCHITECTURE}/release/${DYLIB_NAME}.dylib" $CIRCUIT_FRAMEWORK_PATH/
 
     print_action "CircuitBindings XCFramework created successfully"
 }

--- a/templates/mopro-example-app/ios/ExampleApp/ExampleApp/KeccakDylibCircuitView.swift
+++ b/templates/mopro-example-app/ios/ExampleApp/ExampleApp/KeccakDylibCircuitView.swift
@@ -49,7 +49,7 @@ extension KeccakDylibCircuitView {
 
                     // Use Bundle.main to locate the dynamic library within the app bundle
                     guard let dylibPath =
-                      Bundle.main.path(forResource: "keccak256", ofType: "dylib", inDirectory: "Frameworks")  else {
+                      Bundle.main.path(forResource: "keccak256", ofType: "dylib", inDirectory: "Frameworks/CircuitBindings.framework")  else {
                         throw NSError(domain: "com.example.error", code: 1,
                           userInfo: [NSLocalizedDescriptionKey: "Failed to find keccak256.dylib in app bundle"])
                     }

--- a/templates/mopro-example-app/ios/ExampleApp/Frameworks/CircuitBindings.framework/Info.plist
+++ b/templates/mopro-example-app/ios/ExampleApp/Frameworks/CircuitBindings.framework/Info.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Bundle identifier, usually in reverse DNS format -->
+    <key>CFBundleIdentifier</key>
+    <string>com-example-circuitbindings</string>
+
+    <!-- Bundle name -->
+    <key>CFBundleName</key>
+    <string>keccak256</string>
+
+    <!-- Bundle version, should be incremented with each release -->
+    <key>CFBundleVersion</key>
+    <string>1</string>
+
+    <!-- Bundle short version string, human-readable version, usually [major].[minor].[patch] -->
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.0</string>
+
+    <!-- Executable name, should match the name of the binary inside the framework -->
+    <key>CFBundleExecutable</key>
+    <string>keccak256.dylib</string>
+
+    <!-- Bundle package type, this is always FMWK for macOS/iOS frameworks -->
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+    <!-- <string>BNDL</string> -->
+    <key>MinimumOSVersion</key>
+    <string>15.0</string>
+
+    <!-- Supported interface orientations (iOS only, optional) -->
+    <!-- This is optional and relevant only if your framework includes UI components -->
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
I’m not sure it’s much progress, but the error is different now:
```
ITMS-90868: Missing Bundle Executable - You must include a valid CFBundleExecutable key in your bundle's information property list file for bundle 'ExampleApp.app/Frameworks/CircuitBindings.framework'.
```
Instead of:
```
ITMS-90426: Invalid Swift Support - The SwiftSupport folder is missing. Rebuild your app using the current public (GM) version of Xcode and resubmit it.
```