### PR TITLE
fix: fix export bindings path

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Use Node.js
               uses: actions/setup-node@v4
               with:
-                node-version: '20.x'
+                  node-version: "20.x"
             - name: Install snarkjs
               run: npm install -g snarkjs
             - name: Restore toml
@@ -58,7 +58,12 @@ jobs:
             - name: Test the project for iOS
               run: |
                   cd mopro-example-app/ios/ExampleApp
-                  xcodebuild test -scheme ExampleApp -workspace ExampleApp.xcworkspace -destination "platform=iOS Simulator,OS=17.5,name=iPhone 15 Pro"
+                  xcodebuild test -scheme ExampleApp -workspace ExampleApp.xcworkspace -destination "platform=iOS Simulator,OS=17.5,name=iPhone 15 Pro" -quiet
+            - name: Export bindings
+              run: |
+                  export MOPRO_ROOT=$(PWD) # Export MOPRO_ROOT path
+                  cd mopro-example-app
+                  mopro export-bindings --platforms ios android --destination out
             - name: Get uniffi-version
               if: steps.uniffi-bindgen-linux-restore.outputs.cache-hit != 'true'
               run: echo "UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)" >> $GITHUB_ENV
@@ -69,47 +74,46 @@ jobs:
                   path: /home/runner/.cargo/bin/uniffi-bindgen
                   key: ${{ runner.os }}-uniffi-bindgen-${{ env.UNIFFI_VERSION }}
 
-   
     test-core-and-ffi:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v3
-        - name: Restore toml
-          uses: actions/cache@v4
-          id: toml-linux-restore
-          with:
-            path: /home/runner/.cargo/bin/toml
-            key: ${{ runner.os }}-toml-0.2.3 # version of toml-cli 0.2.3
-        - name: Install circom
-          run: |
-            sudo wget -O /usr/bin/circom https://github.com/iden3/circom/releases/download/v2.1.9/circom-linux-amd64
-            sudo chmod +x /usr/bin/circom
-        - name: Get uniffi-version
-          if: steps.toml-linux-restore.outputs.cache-hit == 'true'
-          run: echo "UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)" >> $GITHUB_ENV
-        - name: Restore uniffi-bindgen
-          uses: actions/cache@v4
-          if: steps.toml-linux-restore.outputs.cache-hit == 'true'
-          id: uniffi-bindgen-linux-restore
-          with:
-              path: /home/runner/.cargo/bin/uniffi-bindgen
-              key: ${{ runner.os }}-uniffi-bindgen-${{ env.UNIFFI_VERSION }}
-        - name: Prepare CI for Core and FFI
-          run: ./scripts/prepare_ci.sh
-        - name: Run core tests
-          run: cd mopro-core && cargo test -- --nocapture
-        - name: Run FFI tests
-        # TODO: Fix this custom jar thing
-          run: |
-            cd mopro-ffi/
-            curl -L https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar -o jna-5.13.0.jar
-            CLASSPATH=jna-5.13.0.jar cargo test -- --nocapture
-        - name: Get uniffi-version
-          if: steps.uniffi-bindgen-linux-restore.outputs.cache-hit != 'true'
-          run: echo "UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)" >> $GITHUB_ENV
-        - name: Save uniffi-bindgen
-          uses: actions/cache@v4
-          if: steps.uniffi-bindgen-linux-restore.outputs.cache-hit != 'true'
-          with:
-              path: /home/runner/.cargo/bin/uniffi-bindgen
-              key: ${{ runner.os }}-uniffi-bindgen-${{ env.UNIFFI_VERSION }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - name: Restore toml
+              uses: actions/cache@v4
+              id: toml-linux-restore
+              with:
+                  path: /home/runner/.cargo/bin/toml
+                  key: ${{ runner.os }}-toml-0.2.3 # version of toml-cli 0.2.3
+            - name: Install circom
+              run: |
+                  sudo wget -O /usr/bin/circom https://github.com/iden3/circom/releases/download/v2.1.9/circom-linux-amd64
+                  sudo chmod +x /usr/bin/circom
+            - name: Get uniffi-version
+              if: steps.toml-linux-restore.outputs.cache-hit == 'true'
+              run: echo "UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)" >> $GITHUB_ENV
+            - name: Restore uniffi-bindgen
+              uses: actions/cache@v4
+              if: steps.toml-linux-restore.outputs.cache-hit == 'true'
+              id: uniffi-bindgen-linux-restore
+              with:
+                  path: /home/runner/.cargo/bin/uniffi-bindgen
+                  key: ${{ runner.os }}-uniffi-bindgen-${{ env.UNIFFI_VERSION }}
+            - name: Prepare CI for Core and FFI
+              run: ./scripts/prepare_ci.sh
+            - name: Run core tests
+              run: cd mopro-core && cargo test -- --nocapture
+            - name: Run FFI tests
+              # TODO: Fix this custom jar thing
+              run: |
+                  cd mopro-ffi/
+                  curl -L https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar -o jna-5.13.0.jar
+                  CLASSPATH=jna-5.13.0.jar cargo test -- --nocapture
+            - name: Get uniffi-version
+              if: steps.uniffi-bindgen-linux-restore.outputs.cache-hit != 'true'
+              run: echo "UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)" >> $GITHUB_ENV
+            - name: Save uniffi-bindgen
+              uses: actions/cache@v4
+              if: steps.uniffi-bindgen-linux-restore.outputs.cache-hit != 'true'
+              with:
+                  path: /home/runner/.cargo/bin/uniffi-bindgen
+                  key: ${{ runner.os }}-uniffi-bindgen-${{ env.UNIFFI_VERSION }}

--- a/mopro-cli/README.md
+++ b/mopro-cli/README.md
@@ -168,20 +168,68 @@ To export bindings to a different directory:
 This will the following files, assuming they've been built, to the destination directory:
 
 ```
-├── SwiftBindings
-│   ├── mopro.swift
-│   ├── moproFFI.h
-│   └── moproFFI.modulemap
-└── libmopro_ffi.a
+├── android
+│   ├── jniLibs
+│   │   └── arm64-v8a
+│   │       └── libuniffi_mopro.so
+│   └── uniffi
+│       └── mopro
+│           └── mopro.kt
+└── ios
+    ├── Bindings
+    │   ├── module.modulemap
+    │   ├── mopro.swift
+    │   └── moproFFI.h
+    └── aarch64-apple-ios-sim
+        └── release
+            └── libmopro_ffi.a
 ```
 
-```
-├── KotlinBindings
-│   └── mopro.kt
-└── JniLibs
-    └── <ARCHITECTURE>
-       └── libuniffi_mopro.so
-```
+#### Use the bindings in iOS
+
+-   Create a XCFramework with `xcodebuild`
+    ```sh
+    xcodebuild -create-xcframework \
+    -library <DESTINATION_DIR>/ios/aarch64-apple-ios-sim/release/libmopro_ffi.a \
+    -headers <DESTINATION_DIR>/ios/Bindings \
+    -output "<DESTINATION_DIR>/ios/Mopro.xcframework"
+    ```
+-   Import both the XCFramework `Mopro.xcframework` and the Swift file bindings `Bindings/mopro.swift` files into your project (drag and drop should work).
+-   Use moproFFI in swift like
+
+    ```swift
+    import moproFFI
+
+    ...
+    try initializeMopro()
+    ...
+    ```
+
+> Reference: https://forgen.tech/en/blog/post/building-an-ios-app-with-rust-using-uniffi
+
+#### Use the bindings in Android
+
+-   Add dependency in `<ANDROID_APP_DIR>/app/build.gradle.kts`
+    ```kts
+     dependencies {
+     ...
+     implementation("net.java.dev.jna:jna:5.13.0@aar")
+     ...
+    }
+    ```
+-   Sync gradle
+-   Move the `<DESTINATION_DIR>/android/jniLibs/` folder to `app/src/main/`
+-   Move the `<DESTINATION_DIR>/android/uniffi/` folder to `app/src/main/java/`
+-   Use moproFFI in kotlin like
+
+    ```kotlin
+      import uniffi.mopro.initializeMopro
+
+      ...
+      initializeMopro()
+      ...
+    ```
+> Reference: https://sal.dev/android/intro-rust-android-uniffi/
 
 ## Contributing
 


### PR DESCRIPTION
- fix export bindings path
- bindings output
```sh
├── android
│   ├── jniLibs
│   │   └── arm64-v8a
│   │       └── libuniffi_mopro.so
│   └── uniffi
│       └── mopro
│           └── mopro.kt
└── ios
    ├── Bindings
    │   ├── module.modulemap
    │   ├── mopro.swift
    │   └── moproFFI.h
    └── aarch64-apple-ios-sim
        └── release
            └── libmopro_ffi.a
```