### PR TITLE
(feat: ci) Added an option to run CI on when a PR is ready for review

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,14 @@
 name: Build and Test
 
-on: [push, pull_request]
+
+on:
+  push:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 env:
     CARGO_TERM_COLOR: always


### PR DESCRIPTION
Currently, if you change your PR from `Draft` to `Ready to Review` the CI do not run on them. This should enable them to run on such event, as well as on several others:
      - **opened (already)**
      - _reopened (added)_
      - _synchronize (added)_
      - _ready_for_review (added)_
