### PR TITLE
Rust formatting fix for `templates/mopro-example-app/core`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,6 +21,8 @@ jobs:
             - uses: actions/checkout@v4
             - name: Check formatting
               run: cargo fmt --all -- --check
+            - name: Check template formating
+              run: cd templates/mopro-example-app && cargo fmt --all -- --check
 
     test-cli:
         runs-on: macos-latest

--- a/templates/mopro-example-app/core/src/lib.rs
+++ b/templates/mopro-example-app/core/src/lib.rs
@@ -3,10 +3,10 @@
 #[cfg(test)]
 mod tests {
     use ark_bn254::Fr;
+    use mopro_core::middleware::circom::serialization::SerializableInputs;
     use mopro_core::middleware::circom::CircomState;
     use num_bigint::BigInt;
     use std::collections::HashMap;
-    use mopro_core::middleware::circom::serialization::SerializableInputs;
 
     #[test]
     fn test_prove_verify_simple() {


### PR DESCRIPTION
Before the `fmt` ci was not checking the issues in the `templates/mopro-example-app`, which resulted in the code not being correctly formatted error when running `cargo fmt  --all -- --check`.

**This PR:**
1. Fixed the code formatting issue.
2. Added the additional check to the ci to catch similar issues.