### PR TITLE
Improvement to Halo2 Prepare phase 

### DIFF
--- a/mopro-core/examples/halo2/fibonacci/src/bin/fibonacci.rs
+++ b/mopro-core/examples/halo2/fibonacci/src/bin/fibonacci.rs
@@ -22,7 +22,7 @@ pub fn main() {
     // Create the path to the `out` directory under the project's root directory
     let out_dir = Path::new(&project_root).join("out");
 
-    // Check if the `keys` directory exists, if not, create it
+    // Check if the `out` directory exists, if not, create it
     if !out_dir.exists() {
         std::fs::create_dir(&out_dir).expect("Unable to create out directory");
     }

--- a/mopro-core/examples/halo2/fibonacci/src/bin/fibonacci.rs
+++ b/mopro-core/examples/halo2/fibonacci/src/bin/fibonacci.rs
@@ -27,15 +27,15 @@ pub fn main() {
     // Generate SRS
     let srs = ParamsKZG::<Bn256>::new(k);
 
-    let srs_path = out_dir.join("fib_srs");
+    let srs_path = out_dir.join("fibonacci_srs");
     write_srs(&srs, srs_path.as_path());
 
     // Generate the proving key - should be loaded from disk in production
     let vk = keygen_vk(&srs, &circuit).expect("keygen_vk should not fail");
-    let vk_path = out_dir.join("fib_vk");
+    let vk_path = out_dir.join("fibonacci_vk");
 
     let pk = keygen_pk(&srs, vk, &circuit).expect("keygen_pk should not fail");
-    let pk_path = out_dir.join("fib_pk");
+    let pk_path = out_dir.join("fibonacci_pk");
 
     write_keys(&pk, pk_path.as_path(), vk_path.as_path());
 

--- a/mopro-core/examples/halo2/fibonacci/src/bin/fibonacci.rs
+++ b/mopro-core/examples/halo2/fibonacci/src/bin/fibonacci.rs
@@ -8,6 +8,13 @@ use halo2_proofs::poly::kzg::commitment::ParamsKZG;
 
 use halo2_circuit::{write_keys, write_srs, FinbonaciCircuit};
 
+/// This binary is picked up by the `mopro prepare` command as a backup option to generate the
+/// srs, as well as proving and verification keys for the circuit when the keys are not found in the
+/// `<YOUR_CIRCUIT>/out` directory.
+///
+/// When integrating your own Halo2 circuit with the mopro-core library, you should:
+/// 1. Provide your own implementation of the `<your_circuit_name>` binary that prepares the keys.
+/// 2. Generate the keys yourself and store them in the `out` directory of your circuit directory.
 pub fn main() {
     // Get the project's root directory from the `CARGO_MANIFEST_DIR` environment variable
     let project_root = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is not set");
@@ -15,10 +22,13 @@ pub fn main() {
     // Create the path to the `out` directory under the project's root directory
     let out_dir = Path::new(&project_root).join("out");
 
-    // Check if the `out` directory exists, if not, create it
+    // Check if the `keys` directory exists, if not, create it
     if !out_dir.exists() {
         std::fs::create_dir(&out_dir).expect("Unable to create out directory");
     }
+
+    // Circuit name
+    let circuit_name = "fibonacci";
 
     // Set up the circuit
     let k = 4;
@@ -27,19 +37,19 @@ pub fn main() {
     // Generate SRS
     let srs = ParamsKZG::<Bn256>::new(k);
 
-    let srs_path = out_dir.join("fibonacci_srs");
+    let srs_path = out_dir.join(format!("{}_srs", circuit_name));
     write_srs(&srs, srs_path.as_path());
 
     // Generate the proving key - should be loaded from disk in production
     let vk = keygen_vk(&srs, &circuit).expect("keygen_vk should not fail");
-    let vk_path = out_dir.join("fibonacci_vk");
+    let vk_path = out_dir.join(format!("{}_vk", circuit_name));
 
     let pk = keygen_pk(&srs, vk, &circuit).expect("keygen_pk should not fail");
-    let pk_path = out_dir.join("fibonacci_pk");
+    let pk_path = out_dir.join(format!("{}_pk", circuit_name));
 
     write_keys(&pk, pk_path.as_path(), vk_path.as_path());
 
-    println!("Preparation finished successfully.");
+    println!("Circuit file preparation finished successfully.");
     println!("SRS stored in {}", srs_path.display());
     println!("Proving key stored in {}", pk_path.display());
     println!("Verification key stored in {}", vk_path.display());

--- a/scripts/cli/prepare.sh
+++ b/scripts/cli/prepare.sh
@@ -187,11 +187,10 @@ halo2_generate_keys() {
   # Execute the cargo run command to generate the keys for the circuit
   # Handle errors if the cargo command fails
   if ! cargo run --release --bin "$CIRCUIT_NAME"; then
-      echo "Error: Failed to generate keys using the circuit binary '$CIRCUIT_NAME'."
-      echo "This step is necessary to generate the keys for the circuit."
-      echo "Consider adding the necessary code to the circuit binary to generate the keys as in the example"
+      echo "Error: Failed to generate keys using the circuit's binary '$CIRCUIT_NAME'."
+      echo "Consider either adding the necessary code to the circuit's binary to generate the keys"
       echo "or generate the keys manually and skip the `prepare` step."
-      echo "Make sure there are the following key files:"
+      echo "Make sure the following key files exist:"
       echo "  - ${CIRCUIT_DIR}/${circuit_srs_path})"
       echo "  - ${CIRCUIT_DIR}/${circuit_pk_path})"
       echo "  - ${CIRCUIT_DIR}/${circuit_vk_path})"

--- a/scripts/cli/prepare.sh
+++ b/scripts/cli/prepare.sh
@@ -170,10 +170,34 @@ halo2_generate_keys() {
     exit 1
   fi
 
-  cd $CIRCUIT_DIR
+  cd "$CIRCUIT_DIR" || exit
 
-  # Generate the keys running the cargo command on the circuit binary
-  cargo run --release --bin $CIRCUIT_NAME
+  local circuit_srs_path="out/${CIRCUIT_NAME}_srs"
+  local circuit_pk_path="out/${CIRCUIT_NAME}_pk"
+  local circuit_vk_path="out/${CIRCUIT_NAME}_vk"
+
+  # Check if all keys already exist
+  if [ -f "$circuit_srs_path" ] && [ -f "$circuit_pk_path" ] && [ -f "$circuit_vk_path" ]; then
+    echo "Keys for the circuit $CIRCUIT_NAME already exist."
+    echo "Skipping the key generation step."
+    return
+  fi
+
+  # Check if the circuit binary exists
+  # Execute the cargo run command to generate the keys for the circuit
+  # Handle errors if the cargo command fails
+  if ! cargo run --release --bin "$CIRCUIT_NAME"; then
+      echo "Error: Failed to generate keys using the circuit binary '$CIRCUIT_NAME'."
+      echo "This step is necessary to generate the keys for the circuit."
+      echo "Consider adding the necessary code to the circuit binary to generate the keys as in the example"
+      echo "or generate the keys manually and skip the `prepare` step."
+      echo "Make sure there are the following key files:"
+      echo "  - ${CIRCUIT_DIR}/${circuit_srs_path})"
+      echo "  - ${CIRCUIT_DIR}/${circuit_pk_path})"
+      echo "  - ${CIRCUIT_DIR}/${circuit_vk_path})"
+
+      exit 1
+  fi
 }
 
 

--- a/templates/mopro-example-app/core/circuits/halo2-fibonacci/src/bin/fibonacci.rs
+++ b/templates/mopro-example-app/core/circuits/halo2-fibonacci/src/bin/fibonacci.rs
@@ -22,7 +22,7 @@ pub fn main() {
     // Create the path to the `out` directory under the project's root directory
     let out_dir = Path::new(&project_root).join("out");
 
-    // Check if the `keys` directory exists, if not, create it
+    // Check if the `out` directory exists, if not, create it
     if !out_dir.exists() {
         std::fs::create_dir(&out_dir).expect("Unable to create out directory");
     }

--- a/templates/mopro-example-app/core/circuits/halo2-fibonacci/src/bin/fibonacci.rs
+++ b/templates/mopro-example-app/core/circuits/halo2-fibonacci/src/bin/fibonacci.rs
@@ -8,6 +8,13 @@ use halo2_proofs::poly::kzg::commitment::ParamsKZG;
 
 use halo2_circuit::{write_keys, write_srs, FinbonaciCircuit};
 
+/// This binary is picked up by the `mopro prepare` command as a backup option to generate the
+/// srs, as well as proving and verification keys for the circuit when the keys are not found in the
+/// `<YOUR_CIRCUIT>/out` directory.
+///
+/// When integrating your own Halo2 circuit with the mopro-core library, you should:
+/// 1. Provide your own implementation of the `<your_circuit_name>` binary that prepares the keys.
+/// 2. Generate the keys yourself and store them in the `out` directory of your circuit directory.
 pub fn main() {
     // Get the project's root directory from the `CARGO_MANIFEST_DIR` environment variable
     let project_root = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is not set");
@@ -15,10 +22,13 @@ pub fn main() {
     // Create the path to the `out` directory under the project's root directory
     let out_dir = Path::new(&project_root).join("out");
 
-    // Check if the `out` directory exists, if not, create it
+    // Check if the `keys` directory exists, if not, create it
     if !out_dir.exists() {
         std::fs::create_dir(&out_dir).expect("Unable to create out directory");
     }
+
+    // Circuit name
+    let circuit_name = "fibonacci";
 
     // Set up the circuit
     let k = 4;
@@ -27,19 +37,19 @@ pub fn main() {
     // Generate SRS
     let srs = ParamsKZG::<Bn256>::new(k);
 
-    let srs_path = out_dir.join("fib_srs");
+    let srs_path = out_dir.join(format!("{}_srs", circuit_name));
     write_srs(&srs, srs_path.as_path());
 
     // Generate the proving key - should be loaded from disk in production
     let vk = keygen_vk(&srs, &circuit).expect("keygen_vk should not fail");
-    let vk_path = out_dir.join("fib_vk");
+    let vk_path = out_dir.join(format!("{}_vk", circuit_name));
 
     let pk = keygen_pk(&srs, vk, &circuit).expect("keygen_pk should not fail");
-    let pk_path = out_dir.join("fib_pk");
+    let pk_path = out_dir.join(format!("{}_pk", circuit_name));
 
     write_keys(&pk, pk_path.as_path(), vk_path.as_path());
 
-    println!("Preparation finished successfully.");
+    println!("Circuit file preparation finished successfully.");
     println!("SRS stored in {}", srs_path.display());
     println!("Proving key stored in {}", pk_path.display());
     println!("Verification key stored in {}", vk_path.display());


### PR DESCRIPTION
1. **Fixed** an issue with hardcoded names of circuit prepare files (keys and `SRS`), now is adjusted based on the circuit name.
2. **Improved** error reporting and suggesting to the user what the issue might be.
3. **Added** an option to manually add circuit files (if they exist, the `mopro prepare` will avoid regenerating them.
4. **Added** an explicit description of the purpose of the binary in the `example/halo2/fibonacci`