### PR TITLE
test(msm): ci test for msm benchmarks and correctness within proper time

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -101,6 +101,10 @@ jobs:
                   export BUILD_CONFIG_PATH="$(pwd)/config-halo2.toml"
                   cd mopro-core
                   cargo test --features=halo2 -- --nocapture
+            - name: Run GPU Benchmarks tests
+              run: |
+                  cd mopro-core
+                  cargo test --features=gpu-benchmarks --lib middleware::gpu_explorations::arkworks_pippenger::tests::test_msm_correctness_small_sample -- --nocapture && cargo test --features=gpu-benchmarks --lib middleware::gpu_explorations::metal::msm::tests::test_msm_correctness_small_sample -- --nocapture
     test-ffi:
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -101,10 +101,7 @@ jobs:
                   export BUILD_CONFIG_PATH="$(pwd)/config-halo2.toml"
                   cd mopro-core
                   cargo test --features=halo2 -- --nocapture
-            - name: Run GPU Benchmarks tests
-              run: |
-                  cd mopro-core
-                  cargo test --features=gpu-benchmarks test_msm_correctness -- --nocapture
+
     test-ffi:
         runs-on: ubuntu-latest
         steps:
@@ -134,3 +131,12 @@ jobs:
                   cd mopro-ffi/
                   curl -L https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar -o jna-5.13.0.jar
                   CLASSPATH=jna-5.13.0.jar cargo test -- --nocapture
+        
+    gpu-benchmarks:
+        runs-on: macos-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Run GPU Benchmarks tests
+              run: |
+                  cd mopro-core
+                  cargo test --features=gpu-benchmarks test_msm_correctness -- --nocapture

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -136,6 +136,25 @@ jobs:
         runs-on: macos-latest
         steps:
             - uses: actions/checkout@v4
+            - name: Install Rust toolchain
+              uses: actions-rs/toolchain@v1
+              with:
+                  toolchain: "1.77"
+                  override: true
+            - name: Run sccache-cache
+              uses: mozilla-actions/sccache-action@v0.0.3
+            - name: Install circom
+              run: |
+                  sudo wget -O ~/.cargo/bin/circom https://github.com/iden3/circom/releases/download/v2.1.9/circom-${{runner.os}}-amd64
+                  sudo chmod +x ~/.cargo/bin/circom
+            - name: Use Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "20.x"
+            - name: Install snarkjs
+              run: npm install -g snarkjs
+            - name: Prepare CI for Core and FFI
+              run: ./scripts/prepare_ci.sh
             - name: Run GPU Benchmarks tests
               run: |
                   cd mopro-core

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -101,6 +101,10 @@ jobs:
                   export BUILD_CONFIG_PATH="$(pwd)/config-halo2.toml"
                   cd mopro-core
                   cargo test --features=halo2 -- --nocapture
+            - name: Run GPU Benchmarks tests
+              run: |
+                  cd mopro-core
+                  cargo test --features=gpu-benchmarks test_msm_correctness -- --nocapture
     test-ffi:
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -101,10 +101,6 @@ jobs:
                   export BUILD_CONFIG_PATH="$(pwd)/config-halo2.toml"
                   cd mopro-core
                   cargo test --features=halo2 -- --nocapture
-            - name: Run GPU Benchmarks tests
-              run: |
-                  cd mopro-core
-                  cargo test --features=gpu-benchmarks --lib middleware::gpu_explorations::arkworks_pippenger::tests::test_msm_correctness_small_sample -- --nocapture && cargo test --features=gpu-benchmarks --lib middleware::gpu_explorations::metal::msm::tests::test_msm_correctness_small_sample -- --nocapture
     test-ffi:
         runs-on: ubuntu-latest
         steps:

--- a/mopro-core/src/middleware/gpu_explorations/arkworks_pippenger.rs
+++ b/mopro-core/src/middleware/gpu_explorations/arkworks_pippenger.rs
@@ -78,13 +78,32 @@ pub fn run_benchmark(
 mod tests {
     use super::*;
 
+    use ark_ec::CurveGroup;
     use ark_serialize::Write;
+    use ark_std::UniformRand;
     use std::fs::File;
 
     const INSTANCE_SIZE: u32 = 16;
     const NUM_INSTANCE: u32 = 10;
     const UTILSPATH: &str = "mopro-core/src/middleware/gpu_explorations/utils/vectors";
     const BENCHMARKSPATH: &str = "mopro-core/gpu_explorations/benchmarks";
+
+    #[test]
+    fn test_msm_correctness_small_sample() {
+        let mut rng = ark_std::rand::thread_rng();
+        let p1 = G::rand(&mut rng);
+        let p2 = G::rand(&mut rng);
+
+        let s1 = ScalarField::rand(&mut rng);
+        let s2 = ScalarField::rand(&mut rng);
+
+        // compare with msm correctness with arkworks ec arithmetics
+        let target_msm = p1 * s1 + p2 * s2;
+
+        let this_msm =
+            <G as VariableBaseMSM>::msm(&[p1.into_affine(), p2.into_affine()], &[s1, s2]).unwrap();
+        assert_eq!(target_msm, this_msm, "This msm is wrongly computed");
+    }
 
     #[test]
     fn test_benchmark_msm() {

--- a/mopro-core/src/middleware/gpu_explorations/metal/msm.rs
+++ b/mopro-core/src/middleware/gpu_explorations/metal/msm.rs
@@ -377,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_msm_correctness_medium_sample() {
-        let dir = format!("{}/{}/{}x{}", preprocess::get_root_path(), UTILSPATH, 10, 5);
+        let dir = format!("{}/{}/{}x{}", preprocess::get_root_path(), UTILSPATH, 8, 5);
         // Init metal (GPU) state
         let mut metal_config = setup_metal_state();
 
@@ -406,7 +406,7 @@ mod tests {
             assert_eq!(metal_msm, arkworks_msm, "This msm is wrongly computed");
             println!(
                 "(pass) {}th instance of size 2^{} is correctly computed",
-                i, INSTANCE_SIZE
+                i, 8
             );
         }
     }


### PR DESCRIPTION
# Issue
The current candidate choice for the MSM benchmarking test takes too long. Specifically, running the command below without the `--release` tag introduces significant time delays when generating the benchmarking instance:
```bash
cargo test --features=gpu-benchmarks test_benchmark_msm
```

# This PR
This PR introduces a lightweight benchmark test using smaller instances, specifically size of 2^10. This allows the tests to be completed within 60 seconds on M3 chips, even without the `--release` flag. Additionally, it includes a test to verify the correctness of the MSM results using both Arkworks built-in EC arithmetic and Arkworks MSM as the expected MSM result.

### Changes
- Benchmark Tests: Implement lightweight benchmark tests with smaller instances (2^10).
- Correctness Tests: Verify MSM results by comparing with Arkworks built-in EC arithmetic and Arkworks MSM.

# CI test command
For the the CI tests, use the following command:
```bash
cargo test --package mopro-core --features=gpu-benchmarks test_msm_correctness
```