### PR TITLE
chore: point docs to v0.0.1 tag

### DIFF
--- a/mopro-web/docs/getting-started.md
+++ b/mopro-web/docs/getting-started.md
@@ -17,7 +17,7 @@ Then, run the following commands:
 1. Clone the mopro repo
 
 ```sh
-git clone https://github.com/zkmopro/mopro.git
+git clone --branch v0.0.1 https://github.com/zkmopro/mopro.git
 ```
 
 2. Go to your newly cloned checkout

--- a/templates/mopro-example-app/core/Cargo.toml
+++ b/templates/mopro-example-app/core/Cargo.toml
@@ -13,7 +13,7 @@ num-bigint = { version = "=0.4.3", default-features = false, features = [
 ark-bn254 = { version = "=0.4.0" }
 
 # FIXME: This doesn't work due to custom build command in mopro-core
-mopro-core = { git = "https://github.com/zkmopro/mopro.git", package = "mopro-core" }
+mopro-core = { git = "https://github.com/zkmopro/mopro.git", tag = "v0.0.1", package = "mopro-core" }
 
 # NOTE: This works, set it to MOPRO_ROOT/mopro-core
 #mopro-core = { path = "../mopro-core", package = "mopro-core" }


### PR DESCRIPTION
This PR updates the docs to instruct the user to clone the `v0.0.1` tag. This should allow us to apply breaking changes to the `main` branch without breaking the docs.