### PR TITLE
fix: use BufReader for zkey

### DIFF
--- a/mopro-ffi/src/circom/mod.rs
+++ b/mopro-ffi/src/circom/mod.rs
@@ -30,8 +30,9 @@ pub fn generate_circom_proof_wtns(
     inputs: HashMap<String, Vec<String>>,
     witness_fn: WtnsFn,
 ) -> Result<GenerateProofResult, MoproError> {
-    let mut file = File::open(zkey_path).map_err(|e| MoproError::CircomError(e.to_string()))?;
-    let zkey = read_zkey(&mut file).map_err(|e| MoproError::CircomError(e.to_string()))?;
+    let file = File::open(zkey_path).map_err(|e| MoproError::CircomError(e.to_string()))?;
+    let mut reader = std::io::BufReader::new(file);
+    let zkey = read_zkey(&mut reader).map_err(|e| MoproError::CircomError(e.to_string()))?;
 
     // Form the inputs
     let bigint_inputs = inputs

--- a/mopro-ffi/src/circom/mod.rs
+++ b/mopro-ffi/src/circom/mod.rs
@@ -91,8 +91,9 @@ pub fn verify_circom_proof(
 ) -> Result<bool, MoproError> {
     let deserialized_proof = serialization::deserialize_proof(proof);
     let deserialized_public_input = serialization::deserialize_inputs(public_input);
-    let mut file = File::open(zkey_path).map_err(|e| MoproError::CircomError(e.to_string()))?;
-    let zkey = read_zkey(&mut file).map_err(|e| MoproError::CircomError(e.to_string()))?;
+    let file = File::open(zkey_path).map_err(|e| MoproError::CircomError(e.to_string()))?;
+    let mut reader = std::io::BufReader::new(file);
+    let zkey = read_zkey(&mut reader).map_err(|e| MoproError::CircomError(e.to_string()))?;
     let start = Instant::now();
     let pvk = prepare_verifying_key(&zkey.0.vk);
 


### PR DESCRIPTION
Related #196 

This PR switches to use a buffered reader for parsing the zkey. The previous implementation was reading from the filesystem too frequently. The buffered reader prevents excess syscalls.

Performance reading `keccak256_256_test_final.zkey` in `release` mode:
- using `File`: `7.57s`
- using #196: `172.96 ms`
- using `BufReader`: `60 ms`

I think `BufReader` is faster than using #196 because it involves fewer memory copy operations, and avoids reading the final sections of the zkey which are unnecessary for making proofs.