### PR TITLE
(fix: android) Updated the dependency version of the `jna` lib to the…

### DIFF
--- a/test-e2e/android/app/build.gradle.kts
+++ b/test-e2e/android/app/build.gradle.kts
@@ -68,6 +68,6 @@ dependencies {
     debugImplementation(libs.androidx.ui.test.manifest)
 
     // Uniffi
-    implementation("net.java.dev.jna:jna:5.7.0@aar")
+    implementation("net.java.dev.jna:jna:5.13.0@aar")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
 }


### PR DESCRIPTION
We had a dependency on the `jna` library for using the bindings in Kotlin lower (`5.7.0`) than the recommended version by `uniffi` (`5.12.0`) as well as the version we use for integration tests (`5.13.0`). 

This caused some issues when I was doing the `proc_marco` PR #201 , as the older version does not work well with the Objects.

## Proposal 

Upgrade the dependency from (`5.7.0`) -> (`5.13.0`)