### PR TITLE
fix: fix dependencies

### DIFF
--- a/mopro-ffi/Cargo.toml
+++ b/mopro-ffi/Cargo.toml
@@ -78,13 +78,11 @@ anyhow = "1.0.86"
 bincode = "1.3.3"
 
 [build-dependencies]
-rust-witness = "0.1.0"
+rust-witness = { version = "0.1.0", optional = true }
 uniffi = { version = "=0.28.0", features = ["build"] }
 
 [dev-dependencies]
 uniffi = { version = "=0.28.0", features = ["bindgen-tests"] }
-# Circom test dependency
-ark-bn254 = { version = "=0.4.0" }
 
 color-eyre = "0.6"
 serde = { version = "1.0", features = ["derive"] }

--- a/mopro-ffi/build.rs
+++ b/mopro-ffi/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    #[cfg(feature = "circom")]
     if std::env::var("MOPRO_FFI_LINK_TEST_WITNESS").unwrap_or_default() != "" {
         rust_witness::transpile::transpile_wasm("../test-vectors/circom".to_string());
     }


### PR DESCRIPTION
should not execute `rust-witness` if `circom` feature is not activated