### PR TITLE
CLI can select target arch

### DIFF
--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -1,14 +1,24 @@
+use std::env;
+use std::collections::HashMap;
+
+use dialoguer::theme::ColorfulTheme;
+use dialoguer::MultiSelect;
+use dialoguer::Select;
+
 use crate::print::print_build_success_message;
 use crate::style;
 use crate::style::blue_bold;
 use crate::style::print_green_bold;
-use dialoguer::theme::ColorfulTheme;
-use dialoguer::MultiSelect;
-use dialoguer::Select;
-use std::env;
 
 const MODES: [&str; 2] = ["debug", "release"];
 const PLATFORMS: [&str; 2] = ["ios", "android"];
+const IOS_ARCHS: [&str; 3] = ["aarch64-apple-ios", "aarch64-apple-ios-sim", "x86_64-apple-ios"];
+const ANDROID_ARCHS: [&str; 4] = [
+    "x86_64-linux-android",
+    "i686-linux-android",
+    "armv7-linux-androideabi",
+    "aarch64-linux-android",
+];
 
 pub fn build_project(
     arg_mode: &Option<String>,
@@ -54,16 +64,40 @@ pub fn build_project(
         }
     };
 
+    let mut selected_architectures: HashMap<String, Vec<String>> = HashMap::new();
+
+    for platform in &platforms {
+        let archs = match platform.as_str() {
+            "ios" => select_architectures("iOS", &IOS_ARCHS)?,
+            "android" => select_architectures("Android", &ANDROID_ARCHS)?,
+            _ => vec![],
+        };
+
+        selected_architectures.insert(platform.clone(), archs);
+    }
+
     if platforms.is_empty() {
         style::print_yellow("No platform selected. Use space to select platform(s).".to_string());
         build_project(&Some(mode), &None)?;
     } else {
         for platform in platforms.clone() {
+            let arch_key = match platform.as_str() {
+                "ios" => "IOS_ARCH",
+                "android" => "ANDROID_ARCH",
+                _ => unreachable!()
+            };
+
+            let selected_arch = selected_architectures
+                .get(&platform)
+                .map(|archs| archs.join(","))
+                .unwrap_or_else(|| "".to_string());
+
             let status = std::process::Command::new("cargo")
                 .arg("run")
                 .arg("--bin")
                 .arg(platform.clone())
                 .env("CONFIGURATION", mode.clone())
+                .env(arch_key, selected_arch)
                 .status()?;
 
             if !status.success() {
@@ -100,6 +134,29 @@ fn select_platforms() -> anyhow::Result<Vec<String>> {
         .iter()
         .map(|&idx| PLATFORMS[idx].to_owned())
         .collect())
+}
+
+fn select_architectures(platform: &str, archs: &[&str]) -> anyhow::Result<Vec<String>> {
+    // At least one architecture must be selected
+    loop {
+        let selected_archs = MultiSelect::with_theme(&ColorfulTheme::default())
+            .with_prompt(format!("Select {} architecture(s) to compile (default: all)", platform))
+            .items(archs)
+            .defaults(&vec![true; archs.len()])
+            .interact()?;
+
+        if selected_archs.is_empty() {
+            style::print_yellow(format!(
+                "No architectures selected for {}. Please select at least one architecture.",
+                platform
+            ));
+        } else {
+            return Ok(selected_archs
+                .iter()
+                .map(|&idx| archs[idx].to_owned())
+                .collect());
+        }
+    }
 }
 
 fn print_binding_message(platforms: Vec<String>) -> anyhow::Result<()> {

--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -12,6 +12,7 @@ use crate::style::print_green_bold;
 
 const MODES: [&str; 2] = ["debug", "release"];
 const PLATFORMS: [&str; 2] = ["ios", "android"];
+// Note that *_ARCH should align with `ios.rs` and `andriod.rs` in "mopro-ffi/src/app_config"
 const IOS_ARCHS: [&str; 3] = [
     "aarch64-apple-ios",
     "aarch64-apple-ios-sim",

--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -1,5 +1,5 @@
-use std::env;
 use std::collections::HashMap;
+use std::env;
 
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::MultiSelect;
@@ -12,7 +12,11 @@ use crate::style::print_green_bold;
 
 const MODES: [&str; 2] = ["debug", "release"];
 const PLATFORMS: [&str; 2] = ["ios", "android"];
-const IOS_ARCHS: [&str; 3] = ["aarch64-apple-ios", "aarch64-apple-ios-sim", "x86_64-apple-ios"];
+const IOS_ARCHS: [&str; 3] = [
+    "aarch64-apple-ios",
+    "aarch64-apple-ios-sim",
+    "x86_64-apple-ios",
+];
 const ANDROID_ARCHS: [&str; 4] = [
     "x86_64-linux-android",
     "i686-linux-android",
@@ -84,7 +88,7 @@ pub fn build_project(
             let arch_key = match platform.as_str() {
                 "ios" => "IOS_ARCH",
                 "android" => "ANDROID_ARCH",
-                _ => unreachable!()
+                _ => unreachable!(),
             };
 
             let selected_arch = selected_architectures
@@ -140,7 +144,10 @@ fn select_architectures(platform: &str, archs: &[&str]) -> anyhow::Result<Vec<St
     // At least one architecture must be selected
     loop {
         let selected_archs = MultiSelect::with_theme(&ColorfulTheme::default())
-            .with_prompt(format!("Select {} architecture(s) to compile (default: all)", platform))
+            .with_prompt(format!(
+                "Select {} architecture(s) to compile (default: all)",
+                platform
+            ))
             .items(archs)
             .defaults(&vec![true; archs.len()])
             .interact()?;

--- a/cli/src/template/init/src/bin/android.rs
+++ b/cli/src/template/init/src/bin/android.rs
@@ -1,5 +1,28 @@
 fn main() {
+    let available_archs = vec![
+        "x86_64-linux-android",
+        "i686-linux-android",
+        "armv7-linux-androideabi",
+        "aarch64-linux-android",
+    ];
+
+    let android_archs: Vec<String> = if let Ok(android_archs) = std::env::var("ANDROID_ARCHS") {
+        android_archs.split(',').map(|arch| arch.to_string()).collect()
+    } else {
+        // Default case: select all supported architectures if none are provided
+        available_archs.iter().map(|arch| arch.to_string()).collect()
+    };
+
+    // Check 'ANDRIOD_ARCH' input validation
+    for arch in &android_archs {
+        assert!(
+            available_archs.contains(&arch.as_str()),
+            "Unsupported architecture: {}",
+            arch
+        );
+    }
+
     // A simple wrapper around a build command provided by mopro.
     // In the future this will likely be published in the mopro crate itself.
-    mopro_ffi::app_config::android::build();
+    mopro_ffi::app_config::android::build(&android_archs);
 }

--- a/cli/src/template/init/src/bin/android.rs
+++ b/cli/src/template/init/src/bin/android.rs
@@ -1,22 +1,20 @@
-fn main() {
-    let available_archs = vec![
-        "x86_64-linux-android",
-        "i686-linux-android",
-        "armv7-linux-androideabi",
-        "aarch64-linux-android",
-    ];
+use mopro_ffi::app_config::android::ANDROID_ARCHS;
 
+fn main() {
     let android_archs: Vec<String> = if let Ok(android_archs) = std::env::var("ANDROID_ARCHS") {
-        android_archs.split(',').map(|arch| arch.to_string()).collect()
+        android_archs
+            .split(',')
+            .map(|arch| arch.to_string())
+            .collect()
     } else {
         // Default case: select all supported architectures if none are provided
-        available_archs.iter().map(|arch| arch.to_string()).collect()
+        ANDROID_ARCHS.iter().map(|arch| arch.to_string()).collect()
     };
 
     // Check 'ANDRIOD_ARCH' input validation
     for arch in &android_archs {
         assert!(
-            available_archs.contains(&arch.as_str()),
+            ANDROID_ARCHS.contains(&arch.as_str()),
             "Unsupported architecture: {}",
             arch
         );

--- a/cli/src/template/init/src/bin/ios.rs
+++ b/cli/src/template/init/src/bin/ios.rs
@@ -1,21 +1,20 @@
+use mopro_ffi::app_config::ios::IOS_ARCHS;
+
 fn main() {
-    let available_archs = vec!["aarch64-apple-ios", "aarch64-apple-ios-sim", "x86_64-apple-ios"];
-    
     let ios_archs: Vec<String> = if let Ok(ios_archs) = std::env::var("IOS_ARCHS") {
         ios_archs.split(',').map(|arch| arch.to_string()).collect()
     } else {
         // Default case: select all supported architectures if none are provided
-        available_archs.iter().map(|&arch| arch.to_string()).collect()
+        IOS_ARCHS.iter().map(|&arch| arch.to_string()).collect()
     };
 
     // Check 'IOS_ARCH' input validation
     for arch in &ios_archs {
         assert!(
-            available_archs.contains(&arch.as_str()),
+            IOS_ARCHS.contains(&arch.as_str()),
             "Unsupported architecture: {}",
             arch
         );
-    
     }
 
     // A simple wrapper around a build command provided by mopro.

--- a/cli/src/template/init/src/bin/ios.rs
+++ b/cli/src/template/init/src/bin/ios.rs
@@ -1,5 +1,24 @@
 fn main() {
+    let available_archs = vec!["aarch64-apple-ios", "aarch64-apple-ios-sim", "x86_64-apple-ios"];
+    
+    let ios_archs: Vec<String> = if let Ok(ios_archs) = std::env::var("IOS_ARCHS") {
+        ios_archs.split(',').map(|arch| arch.to_string()).collect()
+    } else {
+        // Default case: select all supported architectures if none are provided
+        available_archs.iter().map(|&arch| arch.to_string()).collect()
+    };
+
+    // Check 'IOS_ARCH' input validation
+    for arch in &ios_archs {
+        assert!(
+            available_archs.contains(&arch.as_str()),
+            "Unsupported architecture: {}",
+            arch
+        );
+    
+    }
+
     // A simple wrapper around a build command provided by mopro.
     // In the future this will likely be published in the mopro crate itself.
-    mopro_ffi::app_config::ios::build();
+    mopro_ffi::app_config::ios::build(&ios_archs);
 }

--- a/mopro-ffi/src/app_config/android.rs
+++ b/mopro-ffi/src/app_config/android.rs
@@ -10,7 +10,7 @@ use super::install_arch;
 use super::install_ndk;
 use super::mktemp_local;
 
-pub fn build() {
+pub fn build(target_archs: &[String]) {
     let cwd = std::env::current_dir().expect("Failed to get current directory");
     let manifest_dir =
         std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| cwd.to_str().unwrap().to_string());
@@ -18,13 +18,6 @@ pub fn build() {
     let work_dir = mktemp_local(&build_dir);
     let bindings_out = work_dir.join("MoproAndroidBindings");
     let bindings_dest = Path::new(&manifest_dir).join("MoproAndroidBindings");
-
-    let target_archs = vec![
-        "x86_64-linux-android",
-        "i686-linux-android",
-        "armv7-linux-androideabi",
-        "aarch64-linux-android",
-    ];
 
     let mode = std::env::var("CONFIGURATION")
         .unwrap_or_else(|_| "debug".to_string())

--- a/mopro-ffi/src/app_config/android.rs
+++ b/mopro-ffi/src/app_config/android.rs
@@ -10,6 +10,14 @@ use super::install_arch;
 use super::install_ndk;
 use super::mktemp_local;
 
+// This variable should be align with `cli/build.rs`
+pub const ANDROID_ARCHS: [&str; 4] = [
+    "x86_64-linux-android",
+    "i686-linux-android",
+    "armv7-linux-androideabi",
+    "aarch64-linux-android",
+];
+
 pub fn build(target_archs: &[String]) {
     let cwd = std::env::current_dir().expect("Failed to get current directory");
     let manifest_dir =

--- a/mopro-ffi/src/app_config/ios.rs
+++ b/mopro-ffi/src/app_config/ios.rs
@@ -10,7 +10,7 @@ use super::install_arch;
 use super::mktemp_local;
 
 // Load environment variables that are specified by by xcode
-pub fn build() {
+pub fn build(target_archs: &[String]) {
     let cwd = std::env::current_dir().unwrap();
     let manifest_dir =
         std::env::var("CARGO_MANIFEST_DIR").unwrap_or(cwd.to_str().unwrap().to_string());
@@ -23,10 +23,11 @@ pub fn build() {
     let bindings_dest = Path::new(&manifest_dir).join("MoproiOSBindings");
     let framework_out = bindings_out.join("MoproBindings.xcframework");
 
-    let target_archs = vec![
-        vec!["aarch64-apple-ios"],
-        vec!["aarch64-apple-ios-sim", "x86_64-apple-ios"],
-    ];
+    // TODO: remove these hardcoded inputs
+    // let target_archs = vec![
+    //     vec!["aarch64-apple-ios"],
+    //     vec!["aarch64-apple-ios-sim", "x86_64-apple-ios"],
+    // ];
 
     // https://developer.apple.com/documentation/xcode/build-settings-reference#Architectures
     let mode;
@@ -42,9 +43,58 @@ pub fn build() {
         mode = "debug";
     }
 
-    // Take a list of architectures, build them, and combine them into
-    // a single universal binary/archive
-    let build_combined_archs = |archs: &Vec<&str>| -> PathBuf {
+    // // Take a list of architectures, build them, and combine them into
+    // // a single universal binary/archive
+    // let build_combined_archs = |archs: &[&str]| -> Vec<PathBuf> {
+    //     let out_lib_paths: Vec<PathBuf> = archs
+    //         .iter()
+    //         .map(|arch| {
+    //             Path::new(&build_dir).join(Path::new(&format!(
+    //                 "{}/{}/{}/libmopro_bindings.a",
+    //                 build_dir, arch, mode
+    //             )))
+    //         })
+    //         .collect();
+
+    //     for arch in archs {
+    //         install_arch(arch.to_string());
+    //         let mut build_cmd = Command::new("cargo");
+    //         build_cmd.arg("build");
+    //         if mode == "release" {
+    //             build_cmd.arg("--release");
+    //         }
+    //         build_cmd
+    //             .arg("--lib")
+    //             .env("CARGO_BUILD_TARGET_DIR", &build_dir)
+    //             .env("CARGO_BUILD_TARGET", arch)
+    //             .spawn()
+    //             .expect("Failed to spawn cargo build")
+    //             .wait()
+    //             .expect("cargo build errored");
+    //     }
+
+    //     // out_lib_paths
+    //     // TODO: enable made one single lib when release mode
+    //     // now lipo the libraries together
+    //     let mut lipo_cmd = Command::new("lipo");
+    //     let lib_out = mktemp_local(build_dir_path).join("libmopro_bindings.a");
+    //     lipo_cmd
+    //         .arg("-create")
+    //         .arg("-output")
+    //         .arg(lib_out.to_str().unwrap());
+    //     for p in out_lib_paths {
+    //         lipo_cmd.arg(p.to_str().unwrap());
+    //     }
+    //     lipo_cmd
+    //         .spawn()
+    //         .expect("Failed to spawn lipo")
+    //         .wait()
+    //         .expect("lipo command failed");
+
+    //     lib_out
+    // };
+
+    let build_archs = |archs: &[String]| {
         let out_lib_paths: Vec<PathBuf> = archs
             .iter()
             .map(|arch| {
@@ -54,6 +104,7 @@ pub fn build() {
                 )))
             })
             .collect();
+
         for arch in archs {
             install_arch(arch.to_string());
             let mut build_cmd = Command::new("cargo");
@@ -70,23 +121,8 @@ pub fn build() {
                 .wait()
                 .expect("cargo build errored");
         }
-        // now lipo the libraries together
-        let mut lipo_cmd = Command::new("lipo");
-        let lib_out = mktemp_local(build_dir_path).join("libmopro_bindings.a");
-        lipo_cmd
-            .arg("-create")
-            .arg("-output")
-            .arg(lib_out.to_str().unwrap());
-        for p in out_lib_paths {
-            lipo_cmd.arg(p.to_str().unwrap());
-        }
-        lipo_cmd
-            .spawn()
-            .expect("Failed to spawn lipo")
-            .wait()
-            .expect("lipo command failed");
 
-        lib_out
+        out_lib_paths
     };
 
     generate_bindings(
@@ -106,10 +142,8 @@ pub fn build() {
     )
     .expect("Failed to move mopro.swift into place");
 
-    let out_lib_paths: Vec<PathBuf> = target_archs
-        .iter()
-        .map(|v| build_combined_archs(v))
-        .collect();
+    // let out_lib_paths: Vec<PathBuf> = build_combined_archs(target_archs);
+    let out_lib_paths: Vec<PathBuf> = build_archs(target_archs);
 
     let mut xcbuild_cmd = Command::new("xcodebuild");
     xcbuild_cmd.arg("-create-xcframework");

--- a/test-e2e/src/bin/android.rs
+++ b/test-e2e/src/bin/android.rs
@@ -1,11 +1,6 @@
-fn main() {
-    let available_archs = vec![
-        "x86_64-linux-android",
-        "i686-linux-android",
-        "armv7-linux-androideabi",
-        "aarch64-linux-android",
-    ];
+use mopro_ffi::app_config::android::ANDROID_ARCHS;
 
+fn main() {
     let android_archs: Vec<String> = if let Ok(android_archs) = std::env::var("ANDROID_ARCHS") {
         android_archs
             .split(',')
@@ -13,16 +8,13 @@ fn main() {
             .collect()
     } else {
         // Default case: select all supported architectures if none are provided
-        available_archs
-            .iter()
-            .map(|arch| arch.to_string())
-            .collect()
+        ANDROID_ARCHS.iter().map(|arch| arch.to_string()).collect()
     };
 
     // Check 'ANDRIOD_ARCH' input validation
     for arch in &android_archs {
         assert!(
-            available_archs.contains(&arch.as_str()),
+            ANDROID_ARCHS.contains(&arch.as_str()),
             "Unsupported architecture: {}",
             arch
         );

--- a/test-e2e/src/bin/android.rs
+++ b/test-e2e/src/bin/android.rs
@@ -1,3 +1,28 @@
 fn main() {
-    mopro_ffi::app_config::android::build();
+    let available_archs = vec![
+        "x86_64-linux-android",
+        "i686-linux-android",
+        "armv7-linux-androideabi",
+        "aarch64-linux-android",
+    ];
+
+    let android_archs: Vec<String> = if let Ok(android_archs) = std::env::var("ANDROID_ARCHS") {
+        android_archs.split(',').map(|arch| arch.to_string()).collect()
+    } else {
+        // Default case: select all supported architectures if none are provided
+        available_archs.iter().map(|arch| arch.to_string()).collect()
+    };
+
+    // Check 'ANDRIOD_ARCH' input validation
+    for arch in &android_archs {
+        assert!(
+            available_archs.contains(&arch.as_str()),
+            "Unsupported architecture: {}",
+            arch
+        );
+    }
+
+    // A simple wrapper around a build command provided by mopro.
+    // In the future this will likely be published in the mopro crate itself.
+    mopro_ffi::app_config::android::build(&android_archs);
 }

--- a/test-e2e/src/bin/android.rs
+++ b/test-e2e/src/bin/android.rs
@@ -7,10 +7,16 @@ fn main() {
     ];
 
     let android_archs: Vec<String> = if let Ok(android_archs) = std::env::var("ANDROID_ARCHS") {
-        android_archs.split(',').map(|arch| arch.to_string()).collect()
+        android_archs
+            .split(',')
+            .map(|arch| arch.to_string())
+            .collect()
     } else {
         // Default case: select all supported architectures if none are provided
-        available_archs.iter().map(|arch| arch.to_string()).collect()
+        available_archs
+            .iter()
+            .map(|arch| arch.to_string())
+            .collect()
     };
 
     // Check 'ANDRIOD_ARCH' input validation

--- a/test-e2e/src/bin/ios.rs
+++ b/test-e2e/src/bin/ios.rs
@@ -1,3 +1,24 @@
 fn main() {
-    mopro_ffi::app_config::ios::build();
+    let available_archs = vec!["aarch64-apple-ios", "aarch64-apple-ios-sim", "x86_64-apple-ios"];
+    
+    let ios_archs: Vec<String> = if let Ok(ios_archs) = std::env::var("IOS_ARCHS") {
+        ios_archs.split(',').map(|arch| arch.to_string()).collect()
+    } else {
+        // Default case: select all supported architectures if none are provided
+        available_archs.iter().map(|&arch| arch.to_string()).collect()
+    };
+
+    // Check 'IOS_ARCH' input validation
+    for arch in &ios_archs {
+        assert!(
+            available_archs.contains(&arch.as_str()),
+            "Unsupported architecture: {}",
+            arch
+        );
+    
+    }
+
+    // A simple wrapper around a build command provided by mopro.
+    // In the future this will likely be published in the mopro crate itself.
+    mopro_ffi::app_config::ios::build(&ios_archs);
 }

--- a/test-e2e/src/bin/ios.rs
+++ b/test-e2e/src/bin/ios.rs
@@ -1,24 +1,17 @@
-fn main() {
-    let available_archs = vec![
-        "aarch64-apple-ios",
-        "aarch64-apple-ios-sim",
-        "x86_64-apple-ios",
-    ];
+use mopro_ffi::app_config::ios::IOS_ARCHS;
 
+fn main() {
     let ios_archs: Vec<String> = if let Ok(ios_archs) = std::env::var("IOS_ARCHS") {
         ios_archs.split(',').map(|arch| arch.to_string()).collect()
     } else {
         // Default case: select all supported architectures if none are provided
-        available_archs
-            .iter()
-            .map(|&arch| arch.to_string())
-            .collect()
+        IOS_ARCHS.iter().map(|&arch| arch.to_string()).collect()
     };
 
     // Check 'IOS_ARCH' input validation
     for arch in &ios_archs {
         assert!(
-            available_archs.contains(&arch.as_str()),
+            IOS_ARCHS.contains(&arch.as_str()),
             "Unsupported architecture: {}",
             arch
         );

--- a/test-e2e/src/bin/ios.rs
+++ b/test-e2e/src/bin/ios.rs
@@ -1,11 +1,18 @@
 fn main() {
-    let available_archs = vec!["aarch64-apple-ios", "aarch64-apple-ios-sim", "x86_64-apple-ios"];
-    
+    let available_archs = vec![
+        "aarch64-apple-ios",
+        "aarch64-apple-ios-sim",
+        "x86_64-apple-ios",
+    ];
+
     let ios_archs: Vec<String> = if let Ok(ios_archs) = std::env::var("IOS_ARCHS") {
         ios_archs.split(',').map(|arch| arch.to_string()).collect()
     } else {
         // Default case: select all supported architectures if none are provided
-        available_archs.iter().map(|&arch| arch.to_string()).collect()
+        available_archs
+            .iter()
+            .map(|&arch| arch.to_string())
+            .collect()
     };
 
     // Check 'IOS_ARCH' input validation
@@ -15,7 +22,6 @@ fn main() {
             "Unsupported architecture: {}",
             arch
         );
-    
     }
 
     // A simple wrapper around a build command provided by mopro.


### PR DESCRIPTION
- `mopro-ffi:app_config::ios::build` and `mopro-ffi:app_config::android::build` now require `target_arch` as an input instead of being hardcoded value inside the function.
- The build scripts in `cli/src/template/init/bin/*` and `test-e2e/src/bin/*` read the `target_arch` value from the environment variable. If no value is provided, all available architectures are selected by default.
- Did not add `mopro-ffi` crate in the cli for only reading `*_ARCHS` variables. It's too heavy to compile for simple.