### PR TITLE
Refactor/replace plain str with enum

### DIFF
--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -10,7 +10,7 @@ use include_dir::include_dir;
 use include_dir::Dir;
 use toml::Value;
 
-use crate::create::copy_embedded_dir;
+use crate::create::utils::copy_embedded_dir;
 use crate::print::print_build_success_message;
 use crate::style;
 use crate::style::blue_bold;

--- a/cli/src/create.rs
+++ b/cli/src/create.rs
@@ -23,6 +23,27 @@ use crate::print::print_create_react_native_success_message;
 use crate::print::print_create_web_success_message;
 use crate::style;
 
+pub enum APP {
+    IOS,
+    Android,
+    Web,
+    Flutter,
+    ReactNative,
+}
+
+impl From<String> for APP {
+    fn from(apps: String) -> Self {
+        match apps.to_lowercase().as_str() {
+            "ios" => APP::IOS,
+            "android" => APP::Android,
+            "web" => APP::Web,
+            "flutter" => APP::Flutter,
+            "react-native" => APP::ReactNative,
+            _ => panic!("Unknown platform selected."),
+        }
+    }
+}
+
 const TEMPLATES: [&str; 5] = ["ios", "android", "web", "flutter", "react-native"];
 
 pub fn create_project(arg_platform: &Option<String>) -> anyhow::Result<()> {
@@ -40,11 +61,11 @@ pub fn create_project(arg_platform: &Option<String>) -> anyhow::Result<()> {
 
     let project_dir = env::current_dir()?;
 
-    match platform.as_str() {
-        "ios" => {
+    let platform_name = platform.to_lowercase();
+    match platform.clone().into() {
+        APP::IOS => {
             let ios_bindings_dir = check_ios_bindings(&project_dir)?;
 
-            let platform_name = "ios";
             let target_dir = project_dir.join(platform_name);
             if target_dir.exists() {
                 return Err(Error::msg(format!(
@@ -64,10 +85,9 @@ pub fn create_project(arg_platform: &Option<String>) -> anyhow::Result<()> {
 
             print_create_ios_success_message();
         }
-        "android" => {
+        APP::Android => {
             let android_bindings_dir = check_android_bindings(&project_dir)?;
 
-            let platform_name = "android";
             let target_dir = project_dir.join(platform_name);
             fs::create_dir(&target_dir)?;
 
@@ -85,7 +105,7 @@ pub fn create_project(arg_platform: &Option<String>) -> anyhow::Result<()> {
 
             print_create_android_success_message();
         }
-        "web" => {
+        APP::Web => {
             let wasm_bindings_dir = check_web_bindings(&project_dir)?;
             let target_dir = project_dir.join("web");
             fs::create_dir(&target_dir)?;
@@ -108,7 +128,7 @@ pub fn create_project(arg_platform: &Option<String>) -> anyhow::Result<()> {
             fs::remove_dir_all(&wasm_bindings_dir)?;
             print_create_web_success_message();
         }
-        "flutter" => {
+        APP::Flutter => {
             let ios_bindings_dir = check_ios_bindings(&project_dir)?;
             let android_bindings_dir = check_android_bindings(&project_dir)?;
 
@@ -122,7 +142,7 @@ pub fn create_project(arg_platform: &Option<String>) -> anyhow::Result<()> {
             download_and_extract_template(
                 "https://github.com/zkmopro/flutter-app/archive/refs/heads/main.zip",
                 &project_dir,
-                "flutter",
+                platform_name.as_str(),
             )?;
 
             let flutter_dir = project_dir.join("flutter-app-main");
@@ -157,11 +177,11 @@ pub fn create_project(arg_platform: &Option<String>) -> anyhow::Result<()> {
 
             print_create_flutter_success_message();
         }
-        "react-native" => {
+        APP::ReactNative => {
             let ios_bindings_dir = check_ios_bindings(&project_dir)?;
             let android_bindings_dir = check_android_bindings(&project_dir)?;
 
-            let target_dir = project_dir.join("react-native-app");
+            let target_dir = project_dir.join(platform_name.as_str());
             if target_dir.exists() {
                 return Err(Error::msg(format!(
                     "The directory {} already exists. Please remove it and try again.",
@@ -171,7 +191,7 @@ pub fn create_project(arg_platform: &Option<String>) -> anyhow::Result<()> {
             download_and_extract_template(
                 "https://codeload.github.com/zkmopro/react-native-app/zip/refs/heads/main",
                 &project_dir,
-                "react-native",
+                platform.as_str(),
             )?;
 
             let react_native_dir = project_dir.join("react-native-app-main");
@@ -193,9 +213,6 @@ pub fn create_project(arg_platform: &Option<String>) -> anyhow::Result<()> {
             copy_keys(assets_dir)?;
 
             print_create_react_native_success_message();
-        }
-        _ => {
-            return Err(Error::msg("Unknown platform selected."));
         }
     }
 

--- a/cli/src/create.rs
+++ b/cli/src/create.rs
@@ -24,7 +24,7 @@ trait Create {
     fn print_message();
 }
 
-pub enum APP {
+pub enum Framework {
     IOS,
     Android,
     Web,
@@ -32,27 +32,27 @@ pub enum APP {
     ReactNative,
 }
 
-impl From<String> for APP {
+impl From<String> for Framework {
     fn from(app: String) -> Self {
         match app.to_lowercase().as_str() {
-            "ios" => APP::IOS,
-            "android" => APP::Android,
-            "web" => APP::Web,
-            "flutter" => APP::Flutter,
-            "react-native" => APP::ReactNative,
+            "ios" => Framework::IOS,
+            "android" => Framework::Android,
+            "web" => Framework::Web,
+            "flutter" => Framework::Flutter,
+            "react-native" => Framework::ReactNative,
             _ => panic!("Unknown platform selected."),
         }
     }
 }
 
-impl From<APP> for &str {
-    fn from(app: APP) -> Self {
+impl From<Framework> for &str {
+    fn from(app: Framework) -> Self {
         match app {
-            APP::IOS => "ios",
-            APP::Android => "android",
-            APP::Web => "web",
-            APP::Flutter => "flutter",
-            APP::ReactNative => "react-native",
+            Framework::IOS => "ios",
+            Framework::Android => "android",
+            Framework::Web => "web",
+            Framework::Flutter => "flutter",
+            Framework::ReactNative => "react-native",
         }
     }
 }
@@ -74,11 +74,11 @@ pub fn create_project(arg_platform: &Option<String>) -> anyhow::Result<()> {
 
     let project_dir = env::current_dir()?;
     match platform.into() {
-        APP::IOS => Ios::create(project_dir)?,
-        APP::Android => Android::create(project_dir)?,
-        APP::Web => Web::create(project_dir)?,
-        APP::Flutter => Flutter::create(project_dir)?,
-        APP::ReactNative => ReactNative::create(project_dir)?,
+        Framework::IOS => Ios::create(project_dir)?,
+        Framework::Android => Android::create(project_dir)?,
+        Framework::Web => Web::create(project_dir)?,
+        Framework::Flutter => Flutter::create(project_dir)?,
+        Framework::ReactNative => ReactNative::create(project_dir)?,
     }
 
     Ok(())

--- a/cli/src/create.rs
+++ b/cli/src/create.rs
@@ -25,7 +25,7 @@ trait Create {
 }
 
 pub enum Framework {
-    IOS,
+    Ios,
     Android,
     Web,
     Flutter,
@@ -35,7 +35,7 @@ pub enum Framework {
 impl From<String> for Framework {
     fn from(app: String) -> Self {
         match app.to_lowercase().as_str() {
-            "ios" => Framework::IOS,
+            "ios" => Framework::Ios,
             "android" => Framework::Android,
             "web" => Framework::Web,
             "flutter" => Framework::Flutter,
@@ -48,7 +48,7 @@ impl From<String> for Framework {
 impl From<Framework> for &str {
     fn from(app: Framework) -> Self {
         match app {
-            Framework::IOS => "ios",
+            Framework::Ios => "ios",
             Framework::Android => "android",
             Framework::Web => "web",
             Framework::Flutter => "flutter",
@@ -74,7 +74,7 @@ pub fn create_project(arg_platform: &Option<String>) -> anyhow::Result<()> {
 
     let project_dir = env::current_dir()?;
     match platform.into() {
-        Framework::IOS => Ios::create(project_dir)?,
+        Framework::Ios => Ios::create(project_dir)?,
         Framework::Android => Android::create(project_dir)?,
         Framework::Web => Web::create(project_dir)?,
         Framework::Flutter => Flutter::create(project_dir)?,

--- a/cli/src/create.rs
+++ b/cli/src/create.rs
@@ -1,28 +1,28 @@
 use std::env;
-use std::fs;
-use std::fs::File;
-use std::io::Read;
-use std::io::Write;
-use std::path::Path;
 use std::path::PathBuf;
 
+use crate::style;
 use anyhow::Error;
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::Select;
-use include_dir::include_dir;
-use include_dir::Dir;
-use indicatif::ProgressBar;
-use indicatif::ProgressStyle;
-use reqwest::blocking::Client;
-use zip::ZipArchive;
 
-use crate::print::print_create_android_success_message;
-use crate::print::print_create_flutter_success_message;
-use crate::print::print_create_ios_success_message;
-use crate::print::print_create_react_native_success_message;
-use crate::print::print_create_web_success_message;
-use crate::style;
+mod android;
+mod ios;
+use android::Android;
+use ios::Ios;
+mod web;
+use web::Web;
+mod flutter;
+use flutter::Flutter;
+mod react_native;
+use react_native::ReactNative;
+pub mod utils;
 
+trait Create {
+    const NAME: &'static str;
+    fn create(project_dir: PathBuf) -> Result<(), Error>;
+    fn print_message();
+}
 pub enum APP {
     IOS,
     Android,
@@ -60,199 +60,14 @@ pub fn create_project(arg_platform: &Option<String>) -> anyhow::Result<()> {
     };
 
     let project_dir = env::current_dir()?;
-
-    let platform_name = platform.to_lowercase();
-    match platform.clone().into() {
-        APP::IOS => {
-            let ios_bindings_dir = check_ios_bindings(&project_dir)?;
-
-            let target_dir = project_dir.join(platform_name);
-            if target_dir.exists() {
-                return Err(Error::msg(format!(
-                    "The directory {} already exists. Please remove it and try again.",
-                    target_dir.display()
-                )));
-            }
-            fs::create_dir(&target_dir)?;
-
-            env::set_current_dir(&target_dir)?;
-            const IOS_TEMPLATE_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/src/template/ios");
-            copy_embedded_dir(&IOS_TEMPLATE_DIR, &target_dir)?;
-
-            env::set_current_dir(&project_dir)?;
-            copy_ios_bindings(ios_bindings_dir, target_dir.clone())?;
-            copy_keys(target_dir)?;
-
-            print_create_ios_success_message();
-        }
-        APP::Android => {
-            let android_bindings_dir = check_android_bindings(&project_dir)?;
-
-            let target_dir = project_dir.join(platform_name);
-            fs::create_dir(&target_dir)?;
-
-            env::set_current_dir(&target_dir)?;
-            const ANDROID_TEMPLATE_DIR: Dir =
-                include_dir!("$CARGO_MANIFEST_DIR/src/template/android");
-            copy_embedded_dir(&ANDROID_TEMPLATE_DIR, &target_dir)?;
-
-            env::set_current_dir(&project_dir)?;
-            let app_dir = target_dir.join("app");
-            copy_android_bindings(&android_bindings_dir, &app_dir, "java")?;
-
-            let assets_dir = app_dir.join("src/main/assets");
-            copy_keys(assets_dir)?;
-
-            print_create_android_success_message();
-        }
-        APP::Web => {
-            let wasm_bindings_dir = check_web_bindings(&project_dir)?;
-            let target_dir = project_dir.join("web");
-            fs::create_dir(&target_dir)?;
-
-            env::set_current_dir(&target_dir)?;
-            const WEB_TEMPLATE_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/src/template/web");
-            copy_embedded_dir(&WEB_TEMPLATE_DIR, &target_dir)?;
-
-            env::set_current_dir(&project_dir)?;
-
-            let target_wasm_bindings_dir = target_dir.join("MoproWasmBindings");
-            fs::create_dir(target_wasm_bindings_dir.clone())?;
-            copy_dir(&wasm_bindings_dir, &target_wasm_bindings_dir)?;
-
-            let asset_dir = target_dir.join("assets");
-            const HALO2_KEYS_DIR: Dir =
-                include_dir!("$CARGO_MANIFEST_DIR/src/template/init/test-vectors/halo2");
-            copy_embedded_file(&HALO2_KEYS_DIR, &asset_dir)?;
-
-            fs::remove_dir_all(&wasm_bindings_dir)?;
-            print_create_web_success_message();
-        }
-        APP::Flutter => {
-            let ios_bindings_dir = check_ios_bindings(&project_dir)?;
-            let android_bindings_dir = check_android_bindings(&project_dir)?;
-
-            let target_dir = project_dir.join("flutter-app");
-            if target_dir.exists() {
-                return Err(Error::msg(format!(
-                    "The directory {} already exists. Please remove it and try again.",
-                    target_dir.display()
-                )));
-            }
-            download_and_extract_template(
-                "https://github.com/zkmopro/flutter-app/archive/refs/heads/main.zip",
-                &project_dir,
-                platform_name.as_str(),
-            )?;
-
-            let flutter_dir = project_dir.join("flutter-app-main");
-            fs::rename(&flutter_dir, &target_dir)?;
-
-            let xcframeworks_dir = ios_bindings_dir.join("MoproBindings.xcframework");
-            let mopro_swift_file = ios_bindings_dir.join("mopro.swift");
-
-            let mopro_flutter_plugin_dir = target_dir.join("mopro_flutter_plugin");
-            let ios_dir = mopro_flutter_plugin_dir.join("ios");
-            let mopro_bindings_dir = ios_dir.join("MoproBindings.xcframework");
-            let classes_dir = ios_dir.join("Classes");
-
-            fs::remove_dir_all(&mopro_bindings_dir)?;
-            fs::create_dir(&mopro_bindings_dir)?;
-            copy_dir(&xcframeworks_dir, &mopro_bindings_dir)?;
-
-            fs::remove_file(classes_dir.join("mopro.swift"))?;
-            fs::copy(&mopro_swift_file, classes_dir.join("mopro.swift"))?;
-
-            copy_android_bindings(
-                &android_bindings_dir,
-                &target_dir.join("mopro_flutter_plugin/android"),
-                "kotlin",
-            )?;
-
-            let assets_dir = target_dir.join("assets");
-            fs::remove_dir_all(&assets_dir)?;
-            fs::create_dir(&assets_dir)?;
-
-            copy_keys(assets_dir)?;
-
-            print_create_flutter_success_message();
-        }
-        APP::ReactNative => {
-            let ios_bindings_dir = check_ios_bindings(&project_dir)?;
-            let android_bindings_dir = check_android_bindings(&project_dir)?;
-
-            let target_dir = project_dir.join(platform_name.as_str());
-            if target_dir.exists() {
-                return Err(Error::msg(format!(
-                    "The directory {} already exists. Please remove it and try again.",
-                    target_dir.display()
-                )));
-            }
-            download_and_extract_template(
-                "https://codeload.github.com/zkmopro/react-native-app/zip/refs/heads/main",
-                &project_dir,
-                platform.as_str(),
-            )?;
-
-            let react_native_dir = project_dir.join("react-native-app-main");
-            fs::rename(&react_native_dir, &target_dir)?;
-
-            let mopro_module_dir = target_dir.join("modules/mopro");
-            copy_ios_bindings(ios_bindings_dir, mopro_module_dir.join("ios"))?;
-
-            copy_android_bindings(
-                &android_bindings_dir,
-                &mopro_module_dir.join("android"),
-                "java",
-            )?;
-
-            let assets_dir = target_dir.join("assets/keys");
-            fs::remove_dir_all(&assets_dir)?;
-            fs::create_dir(&assets_dir)?;
-
-            copy_keys(assets_dir)?;
-
-            print_create_react_native_success_message();
-        }
+    match platform.into() {
+        APP::IOS => Ios::create(project_dir)?,
+        APP::Android => Android::create(project_dir)?,
+        APP::Web => Web::create(project_dir)?,
+        APP::Flutter => Flutter::create(project_dir)?,
+        APP::ReactNative => ReactNative::create(project_dir)?,
     }
 
-    Ok(())
-}
-
-fn copy_android_bindings(
-    android_bindings_dir: &Path,
-    target_dir: &Path,
-    language: &str,
-) -> anyhow::Result<()> {
-    let jni_libs_name = "jniLibs";
-    let uniffi_name = "uniffi";
-    let jni_libs_path = android_bindings_dir.join(jni_libs_name);
-    let uniffi_path = android_bindings_dir.join(uniffi_name);
-    let main_dir = target_dir.join("src").join("main");
-    let target_jni_libs_path = main_dir.join(jni_libs_name);
-    let target_uniffi_path = main_dir.join(language).join(uniffi_name);
-
-    if target_jni_libs_path.exists() {
-        fs::remove_dir_all(target_jni_libs_path.clone())?;
-    }
-    fs::create_dir(&target_jni_libs_path)?;
-    copy_dir(&jni_libs_path, &target_jni_libs_path)?;
-    if target_uniffi_path.exists() {
-        fs::remove_dir_all(target_uniffi_path.clone())?;
-    }
-    fs::create_dir(&target_uniffi_path)?;
-    copy_dir(&uniffi_path, &target_uniffi_path)?;
-
-    Ok(())
-}
-
-fn copy_ios_bindings(input_dir: PathBuf, output_dir: PathBuf) -> Result<(), Error> {
-    let ios_bindings_target_dir = output_dir.join("MoproiOSBindings");
-    if ios_bindings_target_dir.exists() {
-        fs::remove_dir_all(&ios_bindings_target_dir)?;
-    }
-    fs::create_dir(&ios_bindings_target_dir)?;
-    copy_dir(&input_dir, &ios_bindings_target_dir)?;
     Ok(())
 }
 
@@ -263,158 +78,4 @@ fn select_template() -> anyhow::Result<String> {
         .interact()?;
 
     Ok(TEMPLATES[idx].to_owned())
-}
-
-fn copy_embedded_file(dir: &Dir, output_dir: &Path) -> anyhow::Result<()> {
-    for file in dir.entries() {
-        // Skip .wasm files
-        if file.path().extension().map_or(false, |ext| ext == "wasm") {
-            continue;
-        }
-
-        let relative_path = file.path();
-        let output_path = output_dir.join(relative_path);
-
-        // Create directories as needed
-        if let Some(parent) = output_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-
-        // Write the file to the output directory
-        match file.as_file() {
-            Some(file) => {
-                if let Err(e) = fs::write(&output_path, file.contents()) {
-                    return Err(e.into());
-                }
-            }
-            None => return Ok(()),
-        }
-    }
-    Ok(())
-}
-
-pub fn copy_embedded_dir(dir: &Dir, output_dir: &Path) -> anyhow::Result<()> {
-    for file in dir.entries() {
-        let relative_path = file.path();
-        let output_path = output_dir.join(relative_path);
-
-        // Create directories as needed
-        if let Some(parent) = output_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-
-        // Write the file to the output directory
-        match file.as_file() {
-            Some(file) => {
-                if let Err(e) = fs::write(&output_path, file.contents()) {
-                    return Err(e.into());
-                }
-            }
-            None => {
-                copy_embedded_dir(file.as_dir().unwrap(), output_dir)?;
-            }
-        }
-    }
-    Ok(())
-}
-
-fn copy_dir(input_dir: &Path, output_dir: &Path) -> anyhow::Result<()> {
-    for entry in fs::read_dir(input_dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_dir() {
-            let dir_name = path.file_name().unwrap();
-            let new_output_dir = output_dir.join(dir_name);
-            fs::create_dir(&new_output_dir)?;
-            copy_dir(&path, &new_output_dir)?;
-        } else {
-            let file_name = path.file_name().unwrap();
-            let new_output_file = output_dir.join(file_name);
-            fs::copy(&path, &new_output_file)?;
-        }
-    }
-    Ok(())
-}
-
-fn copy_keys(target_dir: std::path::PathBuf) -> Result<(), anyhow::Error> {
-    const CIRCOM_KEYS_DIR: Dir =
-        include_dir!("$CARGO_MANIFEST_DIR/src/template/init/test-vectors/circom");
-    const HALO2_KEYS_DIR: Dir =
-        include_dir!("$CARGO_MANIFEST_DIR/src/template/init/test-vectors/halo2");
-    copy_embedded_file(&CIRCOM_KEYS_DIR, &target_dir)?;
-    copy_embedded_file(&HALO2_KEYS_DIR, &target_dir)?;
-    Ok(())
-}
-
-fn check_ios_bindings(project_dir: &Path) -> anyhow::Result<PathBuf> {
-    let ios_bindings_dir = project_dir.join("MoproiOSBindings");
-    if ios_bindings_dir.exists() && fs::read_dir(&ios_bindings_dir)?.count() > 0 {
-        Ok(ios_bindings_dir)
-    } else {
-        Err(Error::msg("iOS bindings are required to create the template. Please run 'mopro build' to generate them."))
-    }
-}
-
-fn check_android_bindings(project_dir: &Path) -> anyhow::Result<PathBuf> {
-    let android_bindings_dir = project_dir.join("MoproAndroidBindings");
-    if android_bindings_dir.exists() && fs::read_dir(&android_bindings_dir)?.count() > 0 {
-        Ok(android_bindings_dir)
-    } else {
-        Err(Error::msg("Android bindings are required to create the template. Please run 'mopro build' to generate them."))
-    }
-}
-
-fn check_web_bindings(project_dir: &Path) -> anyhow::Result<PathBuf> {
-    let web_bindings_dir = project_dir.join("MoproWasmBindings");
-    if web_bindings_dir.exists() && fs::read_dir(&web_bindings_dir)?.count() > 0 {
-        Ok(web_bindings_dir)
-    } else {
-        Err(Error::msg("Web(WASM) bindings are required to create the template. Please run 'mopro build' to generate them."))
-    }
-}
-
-fn download_and_extract_template(url: &str, dest: &Path, platform: &str) -> anyhow::Result<()> {
-    let client = Client::new();
-    let mut response = client.get(url).send()?;
-    let spinner = ProgressBar::new_spinner();
-    spinner.set_style(
-        ProgressStyle::default_spinner()
-            .template("{msg} {spinner} {bytes} downloaded")
-            .unwrap(),
-    );
-    spinner.set_message(format!("Downloading {} template...", platform));
-
-    // Save to a temporary file
-    let temp_zip_path = dest.join("template.zip");
-    let mut dest_file = File::create(&temp_zip_path)?;
-
-    // Create a buffer and copy while updating the progress bar
-    let mut buffer = [0u8; 8192];
-    let mut downloaded: u64 = 0;
-    let mut start_time = std::time::Instant::now();
-    loop {
-        let bytes_read = response.read(&mut buffer)?;
-        if bytes_read == 0 {
-            break;
-        }
-        dest_file.write_all(&buffer[..bytes_read])?;
-        downloaded += bytes_read as u64;
-        let current_time = std::time::Instant::now();
-        // Tick every 50 ms
-        if (current_time - start_time).as_millis() > 50 {
-            spinner.set_position(downloaded);
-            start_time = current_time;
-        }
-    }
-
-    spinner.finish_with_message("Download complete!");
-
-    let zip_file = File::open(&temp_zip_path)?;
-    let mut archive = ZipArchive::new(zip_file)?;
-    archive.extract(dest)?;
-
-    // Clean up
-    std::fs::remove_file(&temp_zip_path)?;
-
-    Ok(())
 }

--- a/cli/src/create.rs
+++ b/cli/src/create.rs
@@ -23,6 +23,7 @@ trait Create {
     fn create(project_dir: PathBuf) -> Result<(), Error>;
     fn print_message();
 }
+
 pub enum APP {
     IOS,
     Android,
@@ -32,14 +33,26 @@ pub enum APP {
 }
 
 impl From<String> for APP {
-    fn from(apps: String) -> Self {
-        match apps.to_lowercase().as_str() {
+    fn from(app: String) -> Self {
+        match app.to_lowercase().as_str() {
             "ios" => APP::IOS,
             "android" => APP::Android,
             "web" => APP::Web,
             "flutter" => APP::Flutter,
             "react-native" => APP::ReactNative,
             _ => panic!("Unknown platform selected."),
+        }
+    }
+}
+
+impl From<APP> for &str {
+    fn from(app: APP) -> Self {
+        match app {
+            APP::IOS => "ios",
+            APP::Android => "android",
+            APP::Web => "web",
+            APP::Flutter => "flutter",
+            APP::ReactNative => "react-native",
         }
     }
 }

--- a/cli/src/create/android.rs
+++ b/cli/src/create/android.rs
@@ -5,9 +5,8 @@ use include_dir::include_dir;
 use include_dir::Dir;
 
 use super::Create;
-use crate::create::utils::{
-    check_android_bindings, copy_android_bindings, copy_embedded_dir, copy_keys,
-};
+use crate::create::utils::{check_bindings, copy_android_bindings, copy_embedded_dir, copy_keys};
+use crate::create::APP;
 use crate::print::print_footer_message;
 use crate::style::print_bold;
 use crate::style::print_green_bold;
@@ -18,7 +17,7 @@ impl Create for Android {
     const NAME: &'static str = "android";
 
     fn create(project_dir: PathBuf) -> Result<(), Error> {
-        let android_bindings_dir = check_android_bindings(&project_dir)?;
+        let android_bindings_dir = check_bindings(&project_dir, APP::Android)?;
 
         let target_dir = project_dir.join(Self::NAME);
         fs::create_dir(&target_dir)?;

--- a/cli/src/create/android.rs
+++ b/cli/src/create/android.rs
@@ -6,7 +6,7 @@ use include_dir::Dir;
 
 use super::Create;
 use crate::create::utils::{check_bindings, copy_android_bindings, copy_embedded_dir, copy_keys};
-use crate::create::APP;
+use crate::create::Framework;
 use crate::print::print_footer_message;
 use crate::style::print_bold;
 use crate::style::print_green_bold;
@@ -17,7 +17,7 @@ impl Create for Android {
     const NAME: &'static str = "android";
 
     fn create(project_dir: PathBuf) -> Result<(), Error> {
-        let android_bindings_dir = check_bindings(&project_dir, APP::Android)?;
+        let android_bindings_dir = check_bindings(&project_dir, Framework::Android)?;
 
         let target_dir = project_dir.join(Self::NAME);
         fs::create_dir(&target_dir)?;

--- a/cli/src/create/android.rs
+++ b/cli/src/create/android.rs
@@ -1,0 +1,53 @@
+use std::{env, fs, path::PathBuf};
+
+use anyhow::Error;
+use include_dir::include_dir;
+use include_dir::Dir;
+
+use super::Create;
+use crate::create::utils::{
+    check_android_bindings, copy_android_bindings, copy_embedded_dir, copy_keys,
+};
+use crate::print::print_footer_message;
+use crate::style::print_bold;
+use crate::style::print_green_bold;
+
+pub struct Android;
+
+impl Create for Android {
+    const NAME: &'static str = "android";
+
+    fn create(project_dir: PathBuf) -> Result<(), Error> {
+        let android_bindings_dir = check_android_bindings(&project_dir)?;
+
+        let target_dir = project_dir.join(Self::NAME);
+        fs::create_dir(&target_dir)?;
+
+        env::set_current_dir(&target_dir)?;
+        const ANDROID_TEMPLATE_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/src/template/android");
+        copy_embedded_dir(&ANDROID_TEMPLATE_DIR, &target_dir)?;
+
+        env::set_current_dir(&project_dir)?;
+        let app_dir = target_dir.join("app");
+        copy_android_bindings(&android_bindings_dir, &app_dir, "java")?;
+
+        let assets_dir = app_dir.join("src/main/assets");
+        copy_keys(assets_dir)?;
+
+        Self::print_message();
+        Ok(())
+    }
+
+    fn print_message() {
+        print_green_bold("Template created successfully!".to_string());
+        println!();
+        print_green_bold("Next steps:".to_string());
+        println!();
+        print_green_bold("  You can now use the following command to open the app:".to_string());
+        println!();
+        print_bold(r"    open android -a Android\ Studio ".to_string());
+        println!();
+        print_green_bold("This will open the Android project in Android Studio.".to_string());
+        print_footer_message();
+    }
+}

--- a/cli/src/create/flutter.rs
+++ b/cli/src/create/flutter.rs
@@ -1,0 +1,91 @@
+use anyhow::Error;
+use std::{fs, path::PathBuf};
+
+use super::Create;
+use crate::create::utils::{
+    check_android_bindings, check_ios_bindings, copy_android_bindings, copy_dir, copy_keys,
+    download_and_extract_template,
+};
+use crate::print::print_footer_message;
+use crate::style::print_bold;
+use crate::style::print_green_bold;
+
+pub struct Flutter;
+
+impl Create for Flutter {
+    const NAME: &'static str = "flutter";
+
+    fn create(project_dir: PathBuf) -> Result<(), Error> {
+        let ios_bindings_dir = check_ios_bindings(&project_dir)?;
+        let android_bindings_dir = check_android_bindings(&project_dir)?;
+
+        let target_dir = project_dir.join("flutter-app");
+        if target_dir.exists() {
+            return Err(Error::msg(format!(
+                "The directory {} already exists. Please remove it and try again.",
+                target_dir.display()
+            )));
+        }
+        download_and_extract_template(
+            "https://github.com/zkmopro/flutter-app/archive/refs/heads/main.zip",
+            &project_dir,
+            Self::NAME,
+        )?;
+
+        let flutter_dir = project_dir.join("flutter-app-main");
+        fs::rename(&flutter_dir, &target_dir)?;
+
+        let xcframeworks_dir = ios_bindings_dir.join("MoproBindings.xcframework");
+        let mopro_swift_file = ios_bindings_dir.join("mopro.swift");
+
+        let mopro_flutter_plugin_dir = target_dir.join("mopro_flutter_plugin");
+        let ios_dir = mopro_flutter_plugin_dir.join("ios");
+        let mopro_bindings_dir = ios_dir.join("MoproBindings.xcframework");
+        let classes_dir = ios_dir.join("Classes");
+
+        fs::remove_dir_all(&mopro_bindings_dir)?;
+        fs::create_dir(&mopro_bindings_dir)?;
+        copy_dir(&xcframeworks_dir, &mopro_bindings_dir)?;
+
+        fs::remove_file(classes_dir.join("mopro.swift"))?;
+        fs::copy(&mopro_swift_file, classes_dir.join("mopro.swift"))?;
+
+        copy_android_bindings(
+            &android_bindings_dir,
+            &target_dir.join("mopro_flutter_plugin/android"),
+            "kotlin",
+        )?;
+
+        let assets_dir = target_dir.join("assets");
+        fs::remove_dir_all(&assets_dir)?;
+        fs::create_dir(&assets_dir)?;
+
+        copy_keys(assets_dir)?;
+
+        Self::print_message();
+        Ok(())
+    }
+
+    fn print_message() {
+        print_green_bold("Flutter template created successfully!".to_string());
+        println!();
+        print_green_bold("Next steps:".to_string());
+        println!();
+        print_green_bold(
+            "  You can now use the following command to open the app in Android Studio:"
+                .to_string(),
+        );
+        println!();
+        print_bold(r"    open flutter-app -a Android\ Studio ".to_string());
+        println!();
+        print_green_bold("  or VS Code::".to_string());
+        println!();
+        print_bold(r"    code flutter-app".to_string());
+        println!();
+        print_green_bold(
+            "To learn more about setting up the Flutter app with mopro, visit https://zkmopro.org/docs/setup/flutter-setup/".to_string(),
+        );
+
+        print_footer_message();
+    }
+}

--- a/cli/src/create/flutter.rs
+++ b/cli/src/create/flutter.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use std::{fs, path::PathBuf};
 
-use super::{Create, APP};
+use super::{Create, Framework};
 use crate::create::utils::{
     check_bindings, copy_android_bindings, copy_dir, copy_keys, download_and_extract_template,
 };
@@ -15,8 +15,8 @@ impl Create for Flutter {
     const NAME: &'static str = "flutter";
 
     fn create(project_dir: PathBuf) -> Result<(), Error> {
-        let ios_bindings_dir = check_bindings(&project_dir, APP::IOS)?;
-        let android_bindings_dir = check_bindings(&project_dir, APP::Android)?;
+        let ios_bindings_dir = check_bindings(&project_dir, Framework::IOS)?;
+        let android_bindings_dir = check_bindings(&project_dir, Framework::Android)?;
 
         let target_dir = project_dir.join("flutter-app");
         if target_dir.exists() {

--- a/cli/src/create/flutter.rs
+++ b/cli/src/create/flutter.rs
@@ -1,10 +1,9 @@
 use anyhow::Error;
 use std::{fs, path::PathBuf};
 
-use super::Create;
+use super::{Create, APP};
 use crate::create::utils::{
-    check_android_bindings, check_ios_bindings, copy_android_bindings, copy_dir, copy_keys,
-    download_and_extract_template,
+    check_bindings, copy_android_bindings, copy_dir, copy_keys, download_and_extract_template,
 };
 use crate::print::print_footer_message;
 use crate::style::print_bold;
@@ -16,8 +15,8 @@ impl Create for Flutter {
     const NAME: &'static str = "flutter";
 
     fn create(project_dir: PathBuf) -> Result<(), Error> {
-        let ios_bindings_dir = check_ios_bindings(&project_dir)?;
-        let android_bindings_dir = check_android_bindings(&project_dir)?;
+        let ios_bindings_dir = check_bindings(&project_dir, APP::IOS)?;
+        let android_bindings_dir = check_bindings(&project_dir, APP::Android)?;
 
         let target_dir = project_dir.join("flutter-app");
         if target_dir.exists() {

--- a/cli/src/create/flutter.rs
+++ b/cli/src/create/flutter.rs
@@ -15,7 +15,7 @@ impl Create for Flutter {
     const NAME: &'static str = "flutter";
 
     fn create(project_dir: PathBuf) -> Result<(), Error> {
-        let ios_bindings_dir = check_bindings(&project_dir, Framework::IOS)?;
+        let ios_bindings_dir = check_bindings(&project_dir, Framework::Ios)?;
         let android_bindings_dir = check_bindings(&project_dir, Framework::Android)?;
 
         let target_dir = project_dir.join("flutter-app");
@@ -32,7 +32,7 @@ impl Create for Flutter {
         )?;
 
         let flutter_dir = project_dir.join("flutter-app-main");
-        fs::rename(&flutter_dir, &target_dir)?;
+        fs::rename(flutter_dir, &target_dir)?;
 
         let xcframeworks_dir = ios_bindings_dir.join("MoproBindings.xcframework");
         let mopro_swift_file = ios_bindings_dir.join("mopro.swift");
@@ -47,7 +47,7 @@ impl Create for Flutter {
         copy_dir(&xcframeworks_dir, &mopro_bindings_dir)?;
 
         fs::remove_file(classes_dir.join("mopro.swift"))?;
-        fs::copy(&mopro_swift_file, classes_dir.join("mopro.swift"))?;
+        fs::copy(mopro_swift_file, classes_dir.join("mopro.swift"))?;
 
         copy_android_bindings(
             &android_bindings_dir,

--- a/cli/src/create/ios.rs
+++ b/cli/src/create/ios.rs
@@ -1,0 +1,53 @@
+use anyhow::{Error, Result};
+use include_dir::include_dir;
+use include_dir::Dir;
+use std::{env, fs, path::PathBuf};
+
+use super::Create;
+use crate::create::utils::{check_ios_bindings, copy_embedded_dir, copy_ios_bindings, copy_keys};
+use crate::print::print_footer_message;
+use crate::style::print_bold;
+use crate::style::print_green_bold;
+
+pub struct Ios;
+
+impl Create for Ios {
+    const NAME: &'static str = "ios";
+
+    fn create(project_dir: PathBuf) -> Result<()> {
+        let ios_bindings_dir = check_ios_bindings(&project_dir)?;
+
+        let target_dir = project_dir.join(Self::NAME);
+        if target_dir.exists() {
+            return Err(Error::msg(format!(
+                "The directory {} already exists. Please remove it and try again.",
+                target_dir.display()
+            )));
+        }
+        fs::create_dir(&target_dir)?;
+
+        env::set_current_dir(&target_dir)?;
+        const IOS_TEMPLATE_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/src/template/ios");
+        copy_embedded_dir(&IOS_TEMPLATE_DIR, &target_dir)?;
+
+        env::set_current_dir(&project_dir)?;
+        copy_ios_bindings(ios_bindings_dir, target_dir.clone())?;
+        copy_keys(target_dir)?;
+
+        Self::print_message();
+        Ok(())
+    }
+
+    fn print_message() {
+        print_green_bold("Template created successfully!".to_string());
+        println!();
+        print_green_bold("Next steps:".to_string());
+        println!();
+        print_green_bold("  You can now use the following command to open the app:".to_string());
+        println!();
+        print_bold("    open ios/MoproApp.xcodeproj".to_string());
+        println!();
+        print_green_bold("This will open the iOS project in Xcode.".to_string());
+        print_footer_message();
+    }
+}

--- a/cli/src/create/ios.rs
+++ b/cli/src/create/ios.rs
@@ -16,7 +16,7 @@ impl Create for Ios {
     const NAME: &'static str = "ios";
 
     fn create(project_dir: PathBuf) -> Result<()> {
-        let ios_bindings_dir = check_bindings(&project_dir, Framework::IOS)?;
+        let ios_bindings_dir = check_bindings(&project_dir, Framework::Ios)?;
 
         let target_dir = project_dir.join(Self::NAME);
         if target_dir.exists() {

--- a/cli/src/create/ios.rs
+++ b/cli/src/create/ios.rs
@@ -4,7 +4,8 @@ use include_dir::Dir;
 use std::{env, fs, path::PathBuf};
 
 use super::Create;
-use crate::create::utils::{check_ios_bindings, copy_embedded_dir, copy_ios_bindings, copy_keys};
+use crate::create::utils::{check_bindings, copy_embedded_dir, copy_ios_bindings, copy_keys};
+use crate::create::APP;
 use crate::print::print_footer_message;
 use crate::style::print_bold;
 use crate::style::print_green_bold;
@@ -15,7 +16,7 @@ impl Create for Ios {
     const NAME: &'static str = "ios";
 
     fn create(project_dir: PathBuf) -> Result<()> {
-        let ios_bindings_dir = check_ios_bindings(&project_dir)?;
+        let ios_bindings_dir = check_bindings(&project_dir, APP::IOS)?;
 
         let target_dir = project_dir.join(Self::NAME);
         if target_dir.exists() {

--- a/cli/src/create/ios.rs
+++ b/cli/src/create/ios.rs
@@ -5,7 +5,7 @@ use std::{env, fs, path::PathBuf};
 
 use super::Create;
 use crate::create::utils::{check_bindings, copy_embedded_dir, copy_ios_bindings, copy_keys};
-use crate::create::APP;
+use crate::create::Framework;
 use crate::print::print_footer_message;
 use crate::style::print_bold;
 use crate::style::print_green_bold;
@@ -16,7 +16,7 @@ impl Create for Ios {
     const NAME: &'static str = "ios";
 
     fn create(project_dir: PathBuf) -> Result<()> {
-        let ios_bindings_dir = check_bindings(&project_dir, APP::IOS)?;
+        let ios_bindings_dir = check_bindings(&project_dir, Framework::IOS)?;
 
         let target_dir = project_dir.join(Self::NAME);
         if target_dir.exists() {

--- a/cli/src/create/react_native.rs
+++ b/cli/src/create/react_native.rs
@@ -16,7 +16,7 @@ impl Create for ReactNative {
     const NAME: &'static str = "react-native";
 
     fn create(project_dir: PathBuf) -> Result<()> {
-        let ios_bindings_dir = check_bindings(&project_dir, Framework::IOS)?;
+        let ios_bindings_dir = check_bindings(&project_dir, Framework::Ios)?;
         let android_bindings_dir = check_bindings(&project_dir, Framework::Android)?;
 
         let target_dir = project_dir.join(Self::NAME);
@@ -33,7 +33,7 @@ impl Create for ReactNative {
         )?;
 
         let react_native_dir = project_dir.join("react-native-app-main");
-        fs::rename(&react_native_dir, &target_dir)?;
+        fs::rename(react_native_dir, &target_dir)?;
 
         let mopro_module_dir = target_dir.join("modules/mopro");
         copy_ios_bindings(ios_bindings_dir, mopro_module_dir.join("ios"))?;

--- a/cli/src/create/react_native.rs
+++ b/cli/src/create/react_native.rs
@@ -1,4 +1,4 @@
-use super::{Create, APP};
+use super::{Create, Framework};
 use crate::create::utils::{
     check_bindings, copy_android_bindings, copy_ios_bindings, copy_keys,
     download_and_extract_template,
@@ -16,8 +16,8 @@ impl Create for ReactNative {
     const NAME: &'static str = "react-native";
 
     fn create(project_dir: PathBuf) -> Result<()> {
-        let ios_bindings_dir = check_bindings(&project_dir, APP::IOS)?;
-        let android_bindings_dir = check_bindings(&project_dir, APP::Android)?;
+        let ios_bindings_dir = check_bindings(&project_dir, Framework::IOS)?;
+        let android_bindings_dir = check_bindings(&project_dir, Framework::Android)?;
 
         let target_dir = project_dir.join(Self::NAME);
         if target_dir.exists() {

--- a/cli/src/create/react_native.rs
+++ b/cli/src/create/react_native.rs
@@ -1,0 +1,74 @@
+use super::Create;
+use crate::create::utils::{
+    check_android_bindings, check_ios_bindings, copy_android_bindings, copy_ios_bindings,
+    copy_keys, download_and_extract_template,
+};
+use crate::print::print_footer_message;
+use crate::style::print_bold;
+use crate::style::print_green_bold;
+
+use anyhow::{Error, Result};
+use std::{fs, path::PathBuf};
+
+pub struct ReactNative;
+
+impl Create for ReactNative {
+    const NAME: &'static str = "react-native";
+
+    fn create(project_dir: PathBuf) -> Result<()> {
+        let ios_bindings_dir = check_ios_bindings(&project_dir)?;
+        let android_bindings_dir = check_android_bindings(&project_dir)?;
+
+        let target_dir = project_dir.join(Self::NAME);
+        if target_dir.exists() {
+            return Err(Error::msg(format!(
+                "The directory {} already exists. Please remove it and try again.",
+                target_dir.display()
+            )));
+        }
+        download_and_extract_template(
+            "https://codeload.github.com/zkmopro/react-native-app/zip/refs/heads/main",
+            &project_dir,
+            Self::NAME,
+        )?;
+
+        let react_native_dir = project_dir.join("react-native-app-main");
+        fs::rename(&react_native_dir, &target_dir)?;
+
+        let mopro_module_dir = target_dir.join("modules/mopro");
+        copy_ios_bindings(ios_bindings_dir, mopro_module_dir.join("ios"))?;
+
+        copy_android_bindings(
+            &android_bindings_dir,
+            &mopro_module_dir.join("android"),
+            "java",
+        )?;
+
+        let assets_dir = target_dir.join("assets/keys");
+        fs::remove_dir_all(&assets_dir)?;
+        fs::create_dir(&assets_dir)?;
+
+        copy_keys(assets_dir)?;
+
+        Self::print_message();
+        Ok(())
+    }
+
+    fn print_message() {
+        print_green_bold("React Native template created successfully!".to_string());
+        println!();
+        print_green_bold("Next steps:".to_string());
+        println!();
+        print_green_bold(
+            "  You can now use the following command to open the app in VS Code:".to_string(),
+        );
+        println!();
+        print_bold(r"    code react-native-app".to_string());
+        println!();
+        print_green_bold(
+            "To learn more about setting up the React Native app with mopro, visit https://zkmopro.org/docs/setup/react-native-setup/".to_string(),
+        );
+
+        print_footer_message();
+    }
+}

--- a/cli/src/create/react_native.rs
+++ b/cli/src/create/react_native.rs
@@ -1,7 +1,7 @@
-use super::Create;
+use super::{Create, APP};
 use crate::create::utils::{
-    check_android_bindings, check_ios_bindings, copy_android_bindings, copy_ios_bindings,
-    copy_keys, download_and_extract_template,
+    check_bindings, copy_android_bindings, copy_ios_bindings, copy_keys,
+    download_and_extract_template,
 };
 use crate::print::print_footer_message;
 use crate::style::print_bold;
@@ -16,8 +16,8 @@ impl Create for ReactNative {
     const NAME: &'static str = "react-native";
 
     fn create(project_dir: PathBuf) -> Result<()> {
-        let ios_bindings_dir = check_ios_bindings(&project_dir)?;
-        let android_bindings_dir = check_android_bindings(&project_dir)?;
+        let ios_bindings_dir = check_bindings(&project_dir, APP::IOS)?;
+        let android_bindings_dir = check_bindings(&project_dir, APP::Android)?;
 
         let target_dir = project_dir.join(Self::NAME);
         if target_dir.exists() {

--- a/cli/src/create/utils.rs
+++ b/cli/src/create/utils.rs
@@ -13,7 +13,7 @@ use indicatif::ProgressStyle;
 use reqwest::blocking::Client;
 use zip::ZipArchive;
 
-use super::APP;
+use super::Framework;
 
 pub fn copy_android_bindings(
     android_bindings_dir: &Path,
@@ -133,11 +133,11 @@ pub fn copy_keys(target_dir: std::path::PathBuf) -> Result<()> {
     Ok(())
 }
 
-pub fn check_bindings(project_dir: &Path, app: APP) -> Result<PathBuf> {
+pub fn check_bindings(project_dir: &Path, app: Framework) -> Result<PathBuf> {
     let bindings_nams = match app {
-        APP::IOS => "MoproiOSBindings",
-        APP::Android => "MoproAndroidBindings",
-        APP::Web => "MoproWasmBindings",
+        Framework::IOS => "MoproiOSBindings",
+        Framework::Android => "MoproAndroidBindings",
+        Framework::Web => "MoproWasmBindings",
         _ => {
             let app_str: &str = app.into();
             return Err(Error::msg(format!(

--- a/cli/src/create/utils.rs
+++ b/cli/src/create/utils.rs
@@ -135,7 +135,7 @@ pub fn copy_keys(target_dir: std::path::PathBuf) -> Result<()> {
 
 pub fn check_bindings(project_dir: &Path, app: Framework) -> Result<PathBuf> {
     let bindings_nams = match app {
-        Framework::IOS => "MoproiOSBindings",
+        Framework::Ios => "MoproiOSBindings",
         Framework::Android => "MoproAndroidBindings",
         Framework::Web => "MoproWasmBindings",
         _ => {

--- a/cli/src/create/utils.rs
+++ b/cli/src/create/utils.rs
@@ -1,0 +1,205 @@
+use std::fs;
+use std::fs::File;
+use std::io::Read;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::{Error, Result};
+use include_dir::include_dir;
+use include_dir::Dir;
+use indicatif::ProgressBar;
+use indicatif::ProgressStyle;
+use reqwest::blocking::Client;
+use zip::ZipArchive;
+
+pub fn copy_android_bindings(
+    android_bindings_dir: &Path,
+    target_dir: &Path,
+    language: &str,
+) -> Result<()> {
+    let jni_libs_name = "jniLibs";
+    let uniffi_name = "uniffi";
+    let jni_libs_path = android_bindings_dir.join(jni_libs_name);
+    let uniffi_path = android_bindings_dir.join(uniffi_name);
+    let main_dir = target_dir.join("src").join("main");
+    let target_jni_libs_path = main_dir.join(jni_libs_name);
+    let target_uniffi_path = main_dir.join(language).join(uniffi_name);
+
+    if target_jni_libs_path.exists() {
+        fs::remove_dir_all(target_jni_libs_path.clone())?;
+    }
+    fs::create_dir(&target_jni_libs_path)?;
+    copy_dir(&jni_libs_path, &target_jni_libs_path)?;
+    if target_uniffi_path.exists() {
+        fs::remove_dir_all(target_uniffi_path.clone())?;
+    }
+    fs::create_dir(&target_uniffi_path)?;
+    copy_dir(&uniffi_path, &target_uniffi_path)?;
+
+    Ok(())
+}
+
+pub fn copy_ios_bindings(input_dir: PathBuf, output_dir: PathBuf) -> Result<()> {
+    let ios_bindings_target_dir = output_dir.join("MoproiOSBindings");
+    if ios_bindings_target_dir.exists() {
+        fs::remove_dir_all(&ios_bindings_target_dir)?;
+    }
+    fs::create_dir(&ios_bindings_target_dir)?;
+    copy_dir(&input_dir, &ios_bindings_target_dir)?;
+    Ok(())
+}
+
+pub fn copy_embedded_file(dir: &Dir, output_dir: &Path) -> Result<()> {
+    for file in dir.entries() {
+        // Skip .wasm files
+        if file.path().extension().map_or(false, |ext| ext == "wasm") {
+            continue;
+        }
+
+        let relative_path = file.path();
+        let output_path = output_dir.join(relative_path);
+
+        // Create directories as needed
+        if let Some(parent) = output_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        // Write the file to the output directory
+        match file.as_file() {
+            Some(file) => {
+                if let Err(e) = fs::write(&output_path, file.contents()) {
+                    return Err(e.into());
+                }
+            }
+            None => return Ok(()),
+        }
+    }
+    Ok(())
+}
+
+pub fn copy_embedded_dir(dir: &Dir, output_dir: &Path) -> Result<()> {
+    for file in dir.entries() {
+        let relative_path = file.path();
+        let output_path = output_dir.join(relative_path);
+
+        // Create directories as needed
+        if let Some(parent) = output_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        // Write the file to the output directory
+        match file.as_file() {
+            Some(file) => {
+                if let Err(e) = fs::write(&output_path, file.contents()) {
+                    return Err(e.into());
+                }
+            }
+            None => {
+                copy_embedded_dir(file.as_dir().unwrap(), output_dir)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn copy_dir(input_dir: &Path, output_dir: &Path) -> Result<()> {
+    for entry in fs::read_dir(input_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            let dir_name = path.file_name().unwrap();
+            let new_output_dir = output_dir.join(dir_name);
+            fs::create_dir(&new_output_dir)?;
+            copy_dir(&path, &new_output_dir)?;
+        } else {
+            let file_name = path.file_name().unwrap();
+            let new_output_file = output_dir.join(file_name);
+            fs::copy(&path, &new_output_file)?;
+        }
+    }
+    Ok(())
+}
+
+pub fn copy_keys(target_dir: std::path::PathBuf) -> Result<()> {
+    const CIRCOM_KEYS_DIR: Dir =
+        include_dir!("$CARGO_MANIFEST_DIR/src/template/init/test-vectors/circom");
+    const HALO2_KEYS_DIR: Dir =
+        include_dir!("$CARGO_MANIFEST_DIR/src/template/init/test-vectors/halo2");
+    copy_embedded_file(&CIRCOM_KEYS_DIR, &target_dir)?;
+    copy_embedded_file(&HALO2_KEYS_DIR, &target_dir)?;
+    Ok(())
+}
+
+pub fn check_ios_bindings(project_dir: &Path) -> Result<PathBuf> {
+    let ios_bindings_dir = project_dir.join("MoproiOSBindings");
+    if ios_bindings_dir.exists() && fs::read_dir(&ios_bindings_dir)?.count() > 0 {
+        Ok(ios_bindings_dir)
+    } else {
+        Err(Error::msg("iOS bindings are required to create the template. Please run 'mopro build' to generate them."))
+    }
+}
+
+pub fn check_android_bindings(project_dir: &Path) -> Result<PathBuf> {
+    let android_bindings_dir = project_dir.join("MoproAndroidBindings");
+    if android_bindings_dir.exists() && fs::read_dir(&android_bindings_dir)?.count() > 0 {
+        Ok(android_bindings_dir)
+    } else {
+        Err(Error::msg("Android bindings are required to create the template. Please run 'mopro build' to generate them."))
+    }
+}
+
+pub fn check_web_bindings(project_dir: &Path) -> Result<PathBuf> {
+    let web_bindings_dir = project_dir.join("MoproWasmBindings");
+    if web_bindings_dir.exists() && fs::read_dir(&web_bindings_dir)?.count() > 0 {
+        Ok(web_bindings_dir)
+    } else {
+        Err(Error::msg("Web(WASM) bindings are required to create the template. Please run 'mopro build' to generate them."))
+    }
+}
+
+pub fn download_and_extract_template(url: &str, dest: &Path, platform: &str) -> Result<()> {
+    let client = Client::new();
+    let mut response = client.get(url).send()?;
+    let spinner = ProgressBar::new_spinner();
+    spinner.set_style(
+        ProgressStyle::default_spinner()
+            .template("{msg} {spinner} {bytes} downloaded")
+            .unwrap(),
+    );
+    spinner.set_message(format!("Downloading {} template...", platform));
+
+    // Save to a temporary file
+    let temp_zip_path = dest.join("template.zip");
+    let mut dest_file = File::create(&temp_zip_path)?;
+
+    // Create a buffer and copy while updating the progress bar
+    let mut buffer = [0u8; 8192];
+    let mut downloaded: u64 = 0;
+    let mut start_time = std::time::Instant::now();
+    loop {
+        let bytes_read = response.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        dest_file.write_all(&buffer[..bytes_read])?;
+        downloaded += bytes_read as u64;
+        let current_time = std::time::Instant::now();
+        // Tick every 50 ms
+        if (current_time - start_time).as_millis() > 50 {
+            spinner.set_position(downloaded);
+            start_time = current_time;
+        }
+    }
+
+    spinner.finish_with_message("Download complete!");
+
+    let zip_file = File::open(&temp_zip_path)?;
+    let mut archive = ZipArchive::new(zip_file)?;
+    archive.extract(dest)?;
+
+    // Clean up
+    std::fs::remove_file(&temp_zip_path)?;
+
+    Ok(())
+}

--- a/cli/src/create/utils.rs
+++ b/cli/src/create/utils.rs
@@ -13,6 +13,8 @@ use indicatif::ProgressStyle;
 use reqwest::blocking::Client;
 use zip::ZipArchive;
 
+use super::APP;
+
 pub fn copy_android_bindings(
     android_bindings_dir: &Path,
     target_dir: &Path,
@@ -131,30 +133,28 @@ pub fn copy_keys(target_dir: std::path::PathBuf) -> Result<()> {
     Ok(())
 }
 
-pub fn check_ios_bindings(project_dir: &Path) -> Result<PathBuf> {
-    let ios_bindings_dir = project_dir.join("MoproiOSBindings");
+pub fn check_bindings(project_dir: &Path, app: APP) -> Result<PathBuf> {
+    let bindings_nams = match app {
+        APP::IOS => "MoproiOSBindings",
+        APP::Android => "MoproAndroidBindings",
+        APP::Web => "MoproWasmBindings",
+        _ => {
+            let app_str: &str = app.into();
+            return Err(Error::msg(format!(
+                "Unsupported language/app ({}) selected. ",
+                app_str
+            )));
+        }
+    };
+
+    let ios_bindings_dir = project_dir.join(bindings_nams);
     if ios_bindings_dir.exists() && fs::read_dir(&ios_bindings_dir)?.count() > 0 {
         Ok(ios_bindings_dir)
     } else {
-        Err(Error::msg("iOS bindings are required to create the template. Please run 'mopro build' to generate them."))
-    }
-}
-
-pub fn check_android_bindings(project_dir: &Path) -> Result<PathBuf> {
-    let android_bindings_dir = project_dir.join("MoproAndroidBindings");
-    if android_bindings_dir.exists() && fs::read_dir(&android_bindings_dir)?.count() > 0 {
-        Ok(android_bindings_dir)
-    } else {
-        Err(Error::msg("Android bindings are required to create the template. Please run 'mopro build' to generate them."))
-    }
-}
-
-pub fn check_web_bindings(project_dir: &Path) -> Result<PathBuf> {
-    let web_bindings_dir = project_dir.join("MoproWasmBindings");
-    if web_bindings_dir.exists() && fs::read_dir(&web_bindings_dir)?.count() > 0 {
-        Ok(web_bindings_dir)
-    } else {
-        Err(Error::msg("Web(WASM) bindings are required to create the template. Please run 'mopro build' to generate them."))
+        Err(Error::msg(format!(
+            "{} are required to create the template. Please run 'mopro build' to generate them.",
+            bindings_nams
+        )))
     }
 }
 

--- a/cli/src/create/web.rs
+++ b/cli/src/create/web.rs
@@ -5,7 +5,7 @@ use std::{env, fs, path::PathBuf};
 
 use super::Create;
 use crate::create::utils::{check_bindings, copy_dir, copy_embedded_dir, copy_embedded_file};
-use crate::create::APP;
+use crate::create::Framework;
 use crate::style::print_bold;
 use crate::style::print_green_bold;
 
@@ -15,7 +15,7 @@ impl Create for Web {
     const NAME: &'static str = "web";
 
     fn create(project_dir: PathBuf) -> Result<()> {
-        let wasm_bindings_dir = check_bindings(&project_dir, APP::Web)?;
+        let wasm_bindings_dir = check_bindings(&project_dir, Framework::Web)?;
         let target_dir = project_dir.join(Self::NAME);
         fs::create_dir(&target_dir)?;
 

--- a/cli/src/create/web.rs
+++ b/cli/src/create/web.rs
@@ -4,7 +4,8 @@ use include_dir::Dir;
 use std::{env, fs, path::PathBuf};
 
 use super::Create;
-use crate::create::utils::{check_web_bindings, copy_dir, copy_embedded_dir, copy_embedded_file};
+use crate::create::utils::{check_bindings, copy_dir, copy_embedded_dir, copy_embedded_file};
+use crate::create::APP;
 use crate::style::print_bold;
 use crate::style::print_green_bold;
 
@@ -14,7 +15,7 @@ impl Create for Web {
     const NAME: &'static str = "web";
 
     fn create(project_dir: PathBuf) -> Result<()> {
-        let wasm_bindings_dir = check_web_bindings(&project_dir)?;
+        let wasm_bindings_dir = check_bindings(&project_dir, APP::Web)?;
         let target_dir = project_dir.join(Self::NAME);
         fs::create_dir(&target_dir)?;
 

--- a/cli/src/create/web.rs
+++ b/cli/src/create/web.rs
@@ -1,0 +1,55 @@
+use anyhow::Result;
+use include_dir::include_dir;
+use include_dir::Dir;
+use std::{env, fs, path::PathBuf};
+
+use super::Create;
+use crate::create::utils::{check_web_bindings, copy_dir, copy_embedded_dir, copy_embedded_file};
+use crate::style::print_bold;
+use crate::style::print_green_bold;
+
+pub struct Web;
+
+impl Create for Web {
+    const NAME: &'static str = "web";
+
+    fn create(project_dir: PathBuf) -> Result<()> {
+        let wasm_bindings_dir = check_web_bindings(&project_dir)?;
+        let target_dir = project_dir.join(Self::NAME);
+        fs::create_dir(&target_dir)?;
+
+        env::set_current_dir(&target_dir)?;
+        const WEB_TEMPLATE_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/src/template/web");
+        copy_embedded_dir(&WEB_TEMPLATE_DIR, &target_dir)?;
+
+        env::set_current_dir(&project_dir)?;
+
+        let target_wasm_bindings_dir = target_dir.join("MoproWasmBindings");
+        fs::create_dir(target_wasm_bindings_dir.clone())?;
+        copy_dir(&wasm_bindings_dir, &target_wasm_bindings_dir)?;
+
+        let asset_dir = target_dir.join("assets");
+        const HALO2_KEYS_DIR: Dir =
+            include_dir!("$CARGO_MANIFEST_DIR/src/template/init/test-vectors/halo2");
+        copy_embedded_file(&HALO2_KEYS_DIR, &asset_dir)?;
+
+        fs::remove_dir_all(&wasm_bindings_dir)?;
+
+        Self::print_message();
+        Ok(())
+    }
+
+    fn print_message() {
+        print_green_bold("Template created successfully!".to_string());
+        println!();
+        print_green_bold("Next steps:".to_string());
+        println!();
+        print_green_bold(
+            "  You can now use the following command to start web server:".to_string(),
+        );
+        println!();
+        print_bold(r"    cd web && yarn && yarn start".to_string());
+        println!();
+        print_green_bold("This will start a simple web server for your browser.".to_string());
+    }
+}

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -2,7 +2,7 @@ use crate::style;
 use crate::style::print_bold;
 use crate::style::print_green_bold;
 
-fn print_footer_message() {
+pub fn print_footer_message() {
     println!();
     println!(
         "📚 To learn more about mopro, visit: {}",
@@ -32,83 +32,5 @@ pub(crate) fn print_build_success_message() {
     println!();
     print_green_bold("Run the following command to create templates.".to_string());
     print_bold("   mopro create".to_string());
-    print_footer_message();
-}
-
-pub(crate) fn print_create_ios_success_message() {
-    print_green_bold("Template created successfully!".to_string());
-    println!();
-    print_green_bold("Next steps:".to_string());
-    println!();
-    print_green_bold("  You can now use the following command to open the app:".to_string());
-    println!();
-    print_bold("    open ios/MoproApp.xcodeproj".to_string());
-    println!();
-    print_green_bold("This will open the iOS project in Xcode.".to_string());
-    print_footer_message();
-}
-
-pub(crate) fn print_create_android_success_message() {
-    print_green_bold("Template created successfully!".to_string());
-    println!();
-    print_green_bold("Next steps:".to_string());
-    println!();
-    print_green_bold("  You can now use the following command to open the app:".to_string());
-    println!();
-    print_bold(r"    open android -a Android\ Studio ".to_string());
-    println!();
-    print_green_bold("This will open the Android project in Android Studio.".to_string());
-    print_footer_message();
-}
-
-pub(crate) fn print_create_web_success_message() {
-    print_green_bold("Template created successfully!".to_string());
-    println!();
-    print_green_bold("Next steps:".to_string());
-    println!();
-    print_green_bold("  You can now use the following command to start web server:".to_string());
-    println!();
-    print_bold(r"    cd web && yarn && yarn start".to_string());
-    println!();
-    print_green_bold("This will start a simple web server for your browser.".to_string());
-}
-
-pub(crate) fn print_create_flutter_success_message() {
-    print_green_bold("Flutter template created successfully!".to_string());
-    println!();
-    print_green_bold("Next steps:".to_string());
-    println!();
-    print_green_bold(
-        "  You can now use the following command to open the app in Android Studio:".to_string(),
-    );
-    println!();
-    print_bold(r"    open flutter-app -a Android\ Studio ".to_string());
-    println!();
-    print_green_bold("  or VS Code::".to_string());
-    println!();
-    print_bold(r"    code flutter-app".to_string());
-    println!();
-    print_green_bold(
-        "To learn more about setting up the Flutter app with mopro, visit https://zkmopro.org/docs/setup/flutter-setup/".to_string(),
-    );
-
-    print_footer_message();
-}
-
-pub(crate) fn print_create_react_native_success_message() {
-    print_green_bold("React Native template created successfully!".to_string());
-    println!();
-    print_green_bold("Next steps:".to_string());
-    println!();
-    print_green_bold(
-        "  You can now use the following command to open the app in VS Code:".to_string(),
-    );
-    println!();
-    print_bold(r"    code react-native-app".to_string());
-    println!();
-    print_green_bold(
-        "To learn more about setting up the React Native app with mopro, visit https://zkmopro.org/docs/setup/react-native-setup/".to_string(),
-    );
-
     print_footer_message();
 }


### PR DESCRIPTION
### Two major changes in this PR
1. Using `enum` to replace `String` (or `&str`) in `create.rs`
2. Refactor `create.rs`, moved different platforms to corresponding files (under `create/` folder)
----

### Description
My intention in the first place is to replace `String` with `enum` only. However, during this refactor, I realized there are more things I can do and that's why I refactored `create.rs`. These two changes separated in different commits. If anyone feels any one of them is not okay, then it's easy to remove it.
Most of changes were just moving from one place to another without (or with limited) changes.

### DIsccusion
- Naming: I renamed `platform` to `APP`, the definition of original `platform` looks more like apps or languages for me. That's why I rename the variable. `framework` might be also a good candidate too. Any feedback is welcome.