### PR TITLE
fix: fix ignore files

### DIFF
--- a/cli/src/template/init/.gitignore
+++ b/cli/src/template/init/.gitignore
@@ -1,1 +1,2 @@
 target/
+build/

--- a/test-e2e/.gitignore
+++ b/test-e2e/.gitignore
@@ -1,4 +1,3 @@
-*.udl
 build/
 MoproAndroidBindings/
 MoproiOSBindings/

--- a/test-e2e/src/mopro.udl
+++ b/test-e2e/src/mopro.udl
@@ -1,0 +1,43 @@
+namespace mopro {
+  [Throws=MoproError]
+  GenerateProofResult generate_halo2_proof(string srs_path, string pk_path, record<string, sequence<string>> circuit_inputs);
+
+  [Throws=MoproError]
+  boolean verify_halo2_proof(string srs_path, string vk_path, bytes proof, bytes public_input);
+
+  [Throws=MoproError]
+  GenerateProofResult generate_circom_proof(string zkey_path, record<string, sequence<string>> circuit_inputs);
+
+  [Throws=MoproError]
+  boolean verify_circom_proof(string zkey_path, bytes proof, bytes public_input);
+
+  ProofCalldata to_ethereum_proof(bytes proof);
+  sequence<string> to_ethereum_inputs(bytes inputs);
+};
+
+dictionary GenerateProofResult {
+  bytes proof;
+  bytes inputs;
+};
+
+dictionary G1 {
+  string x;
+  string y;
+};
+
+dictionary G2 {
+  sequence<string> x;
+  sequence<string> y;
+};
+
+dictionary ProofCalldata {
+  G1 a;
+  G2 b;
+  G1 c;
+};
+
+[Error]
+enum MoproError {
+  "CircomError",
+  "Halo2Error",
+};


### PR DESCRIPTION
- UDL file can now be customized, we should not ignore the udl file
- the `mopro-example-app` has `build` folder that can be ignored