### PR TITLE
fix: typos in comments and documentation

### DIFF
--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -135,7 +135,7 @@ pub fn build_project(arg_mode: &Option<String>, arg_platforms: &Option<Vec<Strin
         copy_mopro_wasm_lib()?;
     }
 
-    // Archtecture selection for iOS or Andriod
+    // Architecture selection for iOS or Android
     let selected_architectures = platform.select_archs();
 
     for p in platform.platforms.clone() {

--- a/cli/src/constants.rs
+++ b/cli/src/constants.rs
@@ -47,7 +47,7 @@ impl Mode {
 }
 
 //
-// Architeture Section
+// Architecture Section
 //
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum IosArch {

--- a/docs/docs/setup/web-wasm-setup.md
+++ b/docs/docs/setup/web-wasm-setup.md
@@ -18,7 +18,7 @@ The "mopro-wasm-lib" is the place that compile wasm code eventually. So, it shou
 
 ### 1. Modify 'Cargo.toml' in the "mopro-wasm-lib"
 
-The user-defined circuit implmentation crate should be added as a dependency manually, as illustrated below:
+The user-defined circuit implementation crate should be added as a dependency manually, as illustrated below:
 
 ```rust
 [package]


### PR DESCRIPTION
Hi! Fixed a few typos in code comments and documentation:

- **`build.rs`**: Corrected spelling in a comment (`Archtecture` → `Architecture`, `Andriod` → `Android`).
- **`constants.rs`**: Fixed a typo in a section header (`Architeture` → `Architecture`).
- **`web-wasm-setup.md`**: Fixed a misspelling in documentation (`implmentation` → `implementation`).
