### PR TITLE
Typos correction

### DIFF
--- a/docs/docs/setup/rust-setup.md
+++ b/docs/docs/setup/rust-setup.md
@@ -108,7 +108,7 @@ mopro_ffi::app!();
 
 // This macro is used to define the `get_circom_wtns_fn` function
 // which defines a mapping between zkey filename and witness generator.
-// You can pass multiple comma seperated `(filename, witness_function)` pairs to it.
+// You can pass multiple comma separated `(filename, witness_function)` pairs to it.
 // You can read in the `circom` doc section how you can manually set this function.
 // One way to create the witness generator function is to use the `rust_witness!` above.
 mopro_ffi::set_circom_circuits! {

--- a/docs/versioned_docs/version-0.0.1/getting-started.md
+++ b/docs/versioned_docs/version-0.0.1/getting-started.md
@@ -75,7 +75,7 @@ This only has to be done once when changing the circuit.
 
 ## Build, test and run your project
 
-Depending on what platforms you are targetting, you can run the following commands:
+Depending on what platforms you are targeting, you can run the following commands:
 
 -   Build the project
 

--- a/docs/versioned_docs/version-0.1.0/setup/rust-setup.md
+++ b/docs/versioned_docs/version-0.1.0/setup/rust-setup.md
@@ -108,7 +108,7 @@ mopro_ffi::app!();
 
 // This macro is used to define the `get_circom_wtns_fn` function
 // which defines a mapping between zkey filename and witness generator.
-// You can pass multiple comma seperated `(filename, witness_function)` pairs to it.
+// You can pass multiple comma separated `(filename, witness_function)` pairs to it.
 // You can read in the `circom` doc section how you can manually set this function.
 // One way to create the witness generator function is to use the `rust_witness!` above.
 mopro_ffi::set_circom_circuits! {

--- a/docs/versioned_docs/version-0.1.0/setup/web-wasm-setup.md
+++ b/docs/versioned_docs/version-0.1.0/setup/web-wasm-setup.md
@@ -18,7 +18,7 @@ The "mopro-wasm-lib" is the place that compile wasm code eventually. So, it shou
 
 ### 1. Modify 'Cargo.toml' in the "mopro-wasm-lib"
 
-The user-defined circuit implmentation crate should be added as a dependency manually, as illustrated below:
+The user-defined circuit implementation crate should be added as a dependency manually, as illustrated below:
 
 ```rust
 [package]

--- a/mopro-ffi/src/app_config/constants.rs
+++ b/mopro-ffi/src/app_config/constants.rs
@@ -57,7 +57,7 @@ impl Mode {
 }
 
 //
-// Architeture Section
+// Architecture Section
 //
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum IosArch {


### PR DESCRIPTION
This PR addresses small typos in the documentation and code comments to improve readability and remove inaccuracies.

## Key Changes:
1. **Updated Titles and Terms:**
   - In `constants.rs`, fixed a typo in the header: "Architeture" changed to "Architecture."
   - In `web-wasm-setup.md`, corrected the typo "implmentation" to "implementation."

2. **Corrected Spelling Errors:**
   - `rust-setup.md`: Fixed "seperated" to "separated."
   - `getting-started.md`: Replaced "targetting" with "targeting."

## Why It Matters:
Documentation and code comments should always be clear and accurate. The corrected typos might have confused developers, especially those new to the project.

If you have any thoughts or questions about these changes, feel free to share!
