### PR TITLE
 Corrections to Static Content and Test Command Wording

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ This command starts a local development server and opens up a browser window. Mo
 $ yarn build
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+This command generates static content into the `build` directory and can be served using any static content hosting service.
 
 ### Deployment
 

--- a/mopro-wasm/README.md
+++ b/mopro-wasm/README.md
@@ -18,7 +18,7 @@ from: [Rayon - github](https://github.com/rayon-rs/rayon#usage-with-webassembly)
 
 ## Run tests
 
-Run the fibonacci circuit tests for all backends—"plonk," "hyperplonk," and "gemini"—in the browser in a headless.
+Run the fibonacci circuit tests for all backends—"plonk," "hyperplonk," and "gemini"— in a headless browser.
 
 ```bash
 wasm-pack test --chrome --headless -- --all-features


### PR DESCRIPTION
Old:
"can be served using any static contents hosting service."
New:
"can be served using any static content hosting service."
Reason: The singular "content" is the correct term.

Old:
"Run the fibonacci circuit tests for all backends—"plonk," "hyperplonk," and "gemini"—in the browser in a headless."
New:
"Run the fibonacci circuit tests for all backends—"plonk," "hyperplonk," and "gemini"—in a headless browser."
Reason: The revised phrasing improves clarity and grammatical correctness.