### PR TITLE
Fix Grammar and Clarity in Documentation

### DIFF
--- a/docs/docs/FAQ.md
+++ b/docs/docs/FAQ.md
@@ -35,4 +35,4 @@ Mopro is for both proving and verifying ZKPs on mobile.
 
 ## Does Mopro run natively on a phone?
 
-Yes. Witness and proof generation happens natively in app.
+Yes. Witness and proof generation happen natively in the app.

--- a/docs/docs/community.md
+++ b/docs/docs/community.md
@@ -4,7 +4,7 @@ sidebar_position: 6
 
 # Community and Talks
 
-Join the Telegram group [here](https://t.me/zkmopro). This is the main place where coordination around development takes places.
+Join the Telegram group [here](https://t.me/zkmopro). This is the main place where coordination around development takes place.
 
 ## Talks
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -10,7 +10,7 @@ How? Mopro connects different adapters with different platforms. You can think o
 
 ![mopro adapters and platforms](/img/roadmap.png)
 
-Note that above is a work in progress, and the dashed lines indicate things that are still experimental and/or in an an early stage.
+Note that above is a work in progress, and the dashed lines indicate things that are still experimental and/or in an early stage.
 
 If you just want to get started using mopro, see [getting started](getting-started).
 


### PR DESCRIPTION
docs/docs/FAQ.md

Before: happens natively in app.
After: happen natively in the app.
Fix: Plural verb agreement + added "the" for correctness.
docs/docs/community.md

Before: takes places.
After: takes place.
Fix: Corrected verb form.
docs/docs/intro.md

Before: in an an early stage.
After: in an early stage.
Fix: Removed duplicate "an."