### PR TITLE
fix witness fn type in circom template

### DIFF
--- a/cli/src/template/circom/lib.rs
+++ b/cli/src/template/circom/lib.rs
@@ -2,5 +2,5 @@
 rust_witness::witness!(multiplier2);
 
 mopro_ffi::set_circom_circuits! {
-    ("multiplier2_final.zkey", multiplier2_witness)
+    ("multiplier2_final.zkey", WitnessFn::RustWitness(multiplier2_witness))
 }


### PR DESCRIPTION
We forgot to update template code with witness refactor