### PR TITLE
fix: fix invalid pub const and remove unnecessary #[wasm_bindgen]

### DIFF
--- a/mopro-wasm/tests/wasm.rs
+++ b/mopro-wasm/tests/wasm.rs
@@ -10,15 +10,12 @@ use wasm_bindgen_test::*;
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
-#[wasm_bindgen]
 #[cfg(feature = "plonk")]
 pub fn prove_and_verify_plonk_proof() {
     // Read all at once
-    pub const SRS_KEY: &[u8] = include_bytes!("../../test-vectors/halo2/plonk_fibonacci_srs.bin");
-    pub const PROVING_KEY: &[u8] =
-        include_bytes!("../../test-vectors/halo2/plonk_fibonacci_pk.bin");
-    pub const VERIFYING_KEY: &[u8] =
-        include_bytes!("../../test-vectors/halo2/plonk_fibonacci_vk.bin");
+    const SRS_KEY: &[u8] = include_bytes!("../../test-vectors/halo2/plonk_fibonacci_srs.bin");
+    const PROVING_KEY: &[u8] = include_bytes!("../../test-vectors/halo2/plonk_fibonacci_pk.bin");
+    const VERIFYING_KEY: &[u8] = include_bytes!("../../test-vectors/halo2/plonk_fibonacci_vk.bin");
 
     // Test input
     let mut input = HashMap::new();
@@ -36,16 +33,12 @@ pub fn prove_and_verify_plonk_proof() {
 }
 
 #[wasm_bindgen_test]
-#[wasm_bindgen]
 #[cfg(feature = "hyperplonk")]
 pub fn prove_and_verify_hyperplonk_proof() {
     // Read all at once
-    pub const SRS_KEY: &[u8] =
-        include_bytes!("../../test-vectors/halo2/hyperplonk_fibonacci_srs.bin");
-    pub const PROVING_KEY: &[u8] =
-        include_bytes!("../../test-vectors/halo2/hyperplonk_fibonacci_pk.bin");
-    pub const VERIFYING_KEY: &[u8] =
-        include_bytes!("../../test-vectors/halo2/hyperplonk_fibonacci_vk.bin");
+    const SRS_KEY: &[u8] = include_bytes!("../../test-vectors/halo2/hyperplonk_fibonacci_srs.bin");
+    const PROVING_KEY: &[u8] = include_bytes!("../../test-vectors/halo2/hyperplonk_fibonacci_pk.bin");
+    const VERIFYING_KEY: &[u8] = include_bytes!("../../test-vectors/halo2/hyperplonk_fibonacci_vk.bin");
 
     // Test input
     let mut input = HashMap::new();
@@ -63,15 +56,12 @@ pub fn prove_and_verify_hyperplonk_proof() {
 }
 
 #[wasm_bindgen_test]
-#[wasm_bindgen]
 #[cfg(feature = "gemini")]
 pub fn prove_and_verify_gemini_proof() {
     // Read all at once
-    pub const SRS_KEY: &[u8] = include_bytes!("../../test-vectors/halo2/gemini_fibonacci_srs.bin");
-    pub const PROVING_KEY: &[u8] =
-        include_bytes!("../../test-vectors/halo2/gemini_fibonacci_pk.bin");
-    pub const VERIFYING_KEY: &[u8] =
-        include_bytes!("../../test-vectors/halo2/gemini_fibonacci_vk.bin");
+    const SRS_KEY: &[u8] = include_bytes!("../../test-vectors/halo2/gemini_fibonacci_srs.bin");
+    const PROVING_KEY: &[u8] = include_bytes!("../../test-vectors/halo2/gemini_fibonacci_pk.bin");
+    const VERIFYING_KEY: &[u8] = include_bytes!("../../test-vectors/halo2/gemini_fibonacci_vk.bin");
 
     // Test input
     let mut input = HashMap::new();


### PR DESCRIPTION
Found a small issue: `pub const` inside a function is invalid because `pub` can't be applied to local constants. Simply removed `pub` to make the code compile correctly.  

Also removed `#[wasm_bindgen]` before tests since it's unnecessary—tests aren't exported to WebAssembly, and `#[wasm_bindgen_test]` is sufficient.  
