### PR TITLE
feat: link cpp library with cargo ndk

### DIFF
--- a/mopro-ffi/src/app_config/android.rs
+++ b/mopro-ffi/src/app_config/android.rs
@@ -67,6 +67,7 @@ pub fn build() {
 fn build_for_arch(arch: AndroidArch, build_dir: &Path, bindings_out: &Path, mode: Mode) {
     let arch_str = arch.as_str();
     install_arch(arch_str.to_string());
+    let cpp_lib_dest = bindings_out.join("jniLibs");
 
     let mut build_cmd = Command::new("cargo");
     build_cmd
@@ -81,6 +82,7 @@ fn build_for_arch(arch: AndroidArch, build_dir: &Path, bindings_out: &Path, mode
     build_cmd
         .env("CARGO_BUILD_TARGET_DIR", build_dir)
         .env("CARGO_BUILD_TARGET", arch_str)
+        .env("CARGO_NDK_OUTPUT_PATH", cpp_lib_dest)
         .spawn()
         .expect("Failed to spawn cargo build")
         .wait()


### PR DESCRIPTION
- It will be used in `witnesscalc` and `rapidsnark`
- see: https://github.com/bbqsrc/cargo-ndk?tab=readme-ov-file#linking-against-and-copying-libc_sharedso-into-the-relevant-places-in-the-output-directory