### PR TITLE
fix: Fix misleading comment in Halo2 circuit example

### DIFF
--- a/cli/src/template/halo2/lib.rs
+++ b/cli/src/template/halo2/lib.rs
@@ -1,4 +1,5 @@
-// --- Halo2 Example of using a single proving and verifying circuit ---
+// --- Halo2 Example of using Plonk proving and verifying circuits ---
+
 
 // Module containing the Halo2 circuit logic (FibonacciMoproCircuit)
 


### PR DESCRIPTION
I updated the comment in the Halo2 example to clarify that it demonstrates the use of multiple elements for proving and verifying, rather than a "single circuit".

p.s. This avoids confusion and ensures accuracy in the documentation.