### PR TITLE
chore: fixed typo in panic message

### DIFF
--- a/circom-prover/src/prover/serialization.rs
+++ b/circom-prover/src/prover/serialization.rs
@@ -46,7 +46,7 @@ impl<T: Pairing> From<PublicInputs> for SerializableInputs<T> {
             .iter()
             .map(|n| {
                 if *n > BigUint::from_bytes_le(T::ScalarField::MODULUS.to_bytes_le().as_ref()) {
-                    panic!("Invalid input, lager than MODULUS")
+                    panic!("Invalid input, larger than MODULUS")
                 }
                 T::ScalarField::from_le_bytes_mod_order(n.to_bytes_le().as_ref())
             })


### PR DESCRIPTION
I found a tiny typo in the following line of code:

```rust
                    panic!("Invalid input, lager than MODULUS")
```

The word **"lager"** should be **"larger"**. Here's the corrected version:

```rust
                    panic!("Invalid input, larger than MODULUS")
```

While "lager" is great for a cold drink, it's not quite what we need here.
The message is clearly comparing numbers, so "larger" is the way to go.
Let’s save the beer for later and make sure the logic is on point!