### PR TITLE
Refactor/generate proof result

### DIFF
--- a/circom-prover/Cargo.toml
+++ b/circom-prover/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["test-vectors/*"]
 name = "circom_prover"
 
 [features]
-default = ["rustwitness", "witnesscalc", "arkworks", "ethereum"]
+default = ["rustwitness", "arkworks", "circom-proof"]
 
 # Witness Generation
 rustwitness = ["rust-witness"]
@@ -42,7 +42,7 @@ rapidsnark = [
     "ark-poly",
 ]
 
-ethereum = ["ark-std", "ark-serialize", "ark-ff"]
+circom-proof = ["ark-std", "ark-serialize", "ark-ff"]
 
 [dependencies]
 num = { version = "0.4.0" }

--- a/circom-prover/Cargo.toml
+++ b/circom-prover/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["test-vectors/*"]
 name = "circom_prover"
 
 [features]
-default = ["rustwitness", "arkworks", "ethereum"]
+default = ["rustwitness", "witnesscalc", "arkworks", "ethereum"]
 
 # Witness Generation
 rustwitness = ["rust-witness"]

--- a/circom-prover/src/lib.rs
+++ b/circom-prover/src/lib.rs
@@ -81,8 +81,8 @@ mod tests {
 
         let proof = generate_proof(
             WitnessFn::RustWitness(multiplier2_witness),
-            ProofLib::RapidSnark,
+            ProofLib::Rapidsnark,
         );
-        assert!(verify_proof(proof, ProofLib::RapidSnark));
+        assert!(verify_proof(proof, ProofLib::Rapidsnark));
     }
 }

--- a/circom-prover/src/prover.rs
+++ b/circom-prover/src/prover.rs
@@ -25,7 +25,7 @@ pub struct CircomProof {
 #[derive(Debug, Clone, Copy)]
 pub enum ProofLib {
     Arkworks,
-    RapidSnark,
+    Rapidsnark,
 }
 
 pub fn prove(
@@ -37,7 +37,7 @@ pub fn prove(
         #[cfg(feature = "arkworks")]
         ProofLib::Arkworks => arkworks::generate_circom_proof(zkey_path, witnesses),
         #[cfg(feature = "rapidsnark")]
-        ProofLib::RapidSnark => rapidsnark::generate_circom_proof(zkey_path, witnesses),
+        ProofLib::Rapidsnark => rapidsnark::generate_circom_proof(zkey_path, witnesses),
         #[allow(unreachable_patterns)]
         _ => panic!("Unsupported proof library"),
     }
@@ -48,7 +48,7 @@ pub fn verify(lib: ProofLib, zkey_path: String, proof: CircomProof) -> Result<bo
         #[cfg(feature = "arkworks")]
         ProofLib::Arkworks => arkworks::verify_circom_proof(zkey_path, proof),
         #[cfg(feature = "rapidsnark")]
-        ProofLib::RapidSnark => rapidsnark::verify_circom_proof(zkey_path, proof),
+        ProofLib::Rapidsnark => rapidsnark::verify_circom_proof(zkey_path, proof),
         #[allow(unreachable_patterns)]
         _ => panic!("Unsupported proof library"),
     }

--- a/circom-prover/src/prover.rs
+++ b/circom-prover/src/prover.rs
@@ -1,19 +1,19 @@
 use anyhow::Result;
 use ark_ec::pairing::Pairing;
 use ark_ff::{BigInteger, PrimeField};
-use ethereum::Proof;
+use circom::Proof;
 use num::BigUint;
 use serialization::SerializableInputs;
 use std::{str::FromStr, thread::JoinHandle};
 
 pub mod ark_circom;
+pub mod circom;
+pub mod serialization;
+
 #[cfg(feature = "arkworks")]
 pub mod arkworks;
-#[cfg(feature = "ethereum")]
-pub mod ethereum;
 #[cfg(feature = "rapidsnark")]
 pub mod rapidsnark;
-pub mod serialization;
 
 pub struct PublicInputs(pub Vec<BigUint>);
 
@@ -54,6 +54,9 @@ pub fn verify(lib: ProofLib, zkey_path: String, proof: CircomProof) -> Result<bo
     }
 }
 
+//
+// Helper functions to convert PublicInputs to other types we need
+//
 impl From<Vec<String>> for PublicInputs {
     fn from(src: Vec<String>) -> Self {
         let pi = src

--- a/circom-prover/src/prover.rs
+++ b/circom-prover/src/prover.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
+use ark_ec::pairing::Pairing;
+use ark_ff::{BigInteger, PrimeField};
 use ethereum::Proof;
 use num::BigUint;
-use std::thread::JoinHandle;
+use serialization::SerializableInputs;
+use std::{str::FromStr, thread::JoinHandle};
 
 pub mod ark_circom;
 #[cfg(feature = "arkworks")]
@@ -40,18 +43,56 @@ pub fn prove(
     }
 }
 
-pub fn verify(
-    lib: ProofLib,
-    zkey_path: String,
-    proof: Vec<u8>,
-    public_inputs: PublicInputs,
-) -> Result<bool> {
+pub fn verify(lib: ProofLib, zkey_path: String, proof: CircomProof) -> Result<bool> {
     match lib {
         #[cfg(feature = "arkworks")]
-        ProofLib::Arkworks => arkworks::verify_circom_proof(zkey_path, proof, public_inputs),
+        ProofLib::Arkworks => arkworks::verify_circom_proof(zkey_path, proof),
         #[cfg(feature = "rapidsnark")]
-        ProofLib::RapidSnark => rapidsnark::verify_circom_proof(zkey_path, proof, public_inputs),
+        ProofLib::RapidSnark => rapidsnark::verify_circom_proof(zkey_path, proof),
         #[allow(unreachable_patterns)]
         _ => panic!("Unsupported proof library"),
+    }
+}
+
+impl From<Vec<String>> for PublicInputs {
+    fn from(src: Vec<String>) -> Self {
+        let pi = src
+            .iter()
+            .map(|str| BigUint::from_str(str).unwrap())
+            .collect();
+        PublicInputs(pi)
+    }
+}
+
+impl From<PublicInputs> for Vec<String> {
+    fn from(src: PublicInputs) -> Self {
+        src.0.iter().map(|p| p.to_string()).collect()
+    }
+}
+
+impl<T: Pairing> From<PublicInputs> for SerializableInputs<T> {
+    fn from(src: PublicInputs) -> SerializableInputs<T> {
+        let si = src
+            .0
+            .iter()
+            .map(|n| {
+                if *n > BigUint::from_bytes_le(T::ScalarField::MODULUS.to_bytes_le().as_ref()) {
+                    panic!("Invalid input, lager than MODULUS")
+                }
+                T::ScalarField::from_le_bytes_mod_order(n.to_bytes_le().as_ref())
+            })
+            .collect();
+        SerializableInputs(si)
+    }
+}
+
+impl<T: Pairing> From<SerializableInputs<T>> for PublicInputs {
+    fn from(src: SerializableInputs<T>) -> PublicInputs {
+        let pi = src
+            .0
+            .iter()
+            .map(|&si| BigUint::from_bytes_le(si.into_bigint().to_bytes_le().as_ref()))
+            .collect();
+        PublicInputs(pi)
     }
 }

--- a/circom-prover/src/prover/circom.rs
+++ b/circom-prover/src/prover/circom.rs
@@ -262,7 +262,7 @@ fn point_to_biguint<F: PrimeField>(point: F) -> BigUint {
 
 #[cfg(test)]
 mod tests {
-    use crate::prover::ethereum::{biguint_to_point, point_to_biguint, Inputs, Proof, G1, G2};
+    use crate::prover::circom::{biguint_to_point, point_to_biguint, Inputs, Proof, G1, G2};
     use num::BigUint;
 
     mod bn254 {

--- a/circom-prover/src/prover/ethereum.rs
+++ b/circom-prover/src/prover/ethereum.rs
@@ -6,16 +6,15 @@ use ark_bls12_381::{
     Bls12_381, Fq as bls12_381_fq, Fq2 as bls12_381_Fq2, Fr as bls12_381_Fr,
     G1Affine as bls12_381_G1Affine, G2Affine as bls12_381_G2Affine,
 };
-use ark_ec::AffineRepr;
-use ark_ff::{BigInteger, PrimeField};
-use num::BigUint;
-use num_traits::Zero;
-
 use ark_bn254::{
     Bn254, Fq as bn254_Fq, Fq2 as bn254_Fq2, Fr as bn254_Fr, G1Affine as bn254_G1Affine,
     G2Affine as bn254_G2Affine,
 };
+use ark_ec::AffineRepr;
+use ark_ff::{BigInteger, PrimeField};
 use ark_serialize::CanonicalDeserialize;
+use num::BigUint;
+use num_traits::Zero;
 
 pub const PROTOCOL_GROTH16: &str = "groth16";
 pub const CURVE_BN254: &str = "bn128";
@@ -225,7 +224,7 @@ impl From<ark_groth16::Proof<Bls12_381>> for Proof {
 }
 
 impl From<Proof> for ark_groth16::Proof<Bn254> {
-    fn from(src: Proof) -> ark_groth16::Proof<Bn254> {
+    fn from(src: Proof) -> Self {
         ark_groth16::Proof {
             a: src.a.to_bn254(),
             b: src.b.to_bn254(),
@@ -235,7 +234,7 @@ impl From<Proof> for ark_groth16::Proof<Bn254> {
 }
 
 impl From<Proof> for ark_groth16::Proof<Bls12_381> {
-    fn from(src: Proof) -> ark_groth16::Proof<Bls12_381> {
+    fn from(src: Proof) -> Self {
         ark_groth16::Proof {
             a: src.a.to_bls12_381(),
             b: src.b.to_bls12_381(),

--- a/circom-prover/src/prover/rapidsnark.rs
+++ b/circom-prover/src/prover/rapidsnark.rs
@@ -10,6 +10,7 @@ use serde_json::json;
 use std::thread::JoinHandle;
 use std::{fs::File, str::FromStr};
 
+use super::serialization::SerializableProof;
 use super::{
     ark_circom::read_proving_key,
     serialization::{self, SerializableInputs},
@@ -64,13 +65,12 @@ pub fn generate_circom_proof(
     })
 }
 
-pub fn verify_circom_proof(
-    zkey_path: String,
-    proof: Vec<u8>,
-    public_inputs: PublicInputs,
-) -> Result<bool> {
-    let proof_parsed = serialization::deserialize_proof::<Bn254>(proof);
-    let public_inputs_parsed: SerializableInputs<Bn254> = public_inputs.into();
+pub fn verify_circom_proof(zkey_path: String, proof: CircomProof) -> Result<bool> {
+    let serialized_proof =
+        serialization::serialize_proof::<Bn254>(&SerializableProof(proof.proof.into()));
+    let proof_parsed = serialization::deserialize_proof::<Bn254>(serialized_proof);
+    let public_inputs_parsed: SerializableInputs<Bn254> = proof.pub_inputs.into();
+
     let pi_a: Vec<String> = vec![
         proof_parsed.0.a.x.to_string(),
         proof_parsed.0.a.y.to_string(),

--- a/circom-prover/src/prover/serialization.rs
+++ b/circom-prover/src/prover/serialization.rs
@@ -1,11 +1,8 @@
 use anyhow::Result;
 use ark_ec::pairing::Pairing;
-use ark_ff::{BigInteger, PrimeField};
 use ark_groth16::{Proof, ProvingKey};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use num::BigUint;
 
-use super::PublicInputs;
 #[derive(CanonicalSerialize, CanonicalDeserialize, Clone, Debug)]
 pub struct SerializableProvingKey<T: Pairing>(pub ProvingKey<T>);
 
@@ -37,33 +34,6 @@ pub fn serialize_inputs<T: Pairing>(inputs: &SerializableInputs<T>) -> Vec<u8> {
 
 pub fn deserialize_inputs<T: Pairing>(data: Vec<u8>) -> SerializableInputs<T> {
     SerializableInputs::deserialize_uncompressed(&mut &data[..]).expect("Deserialization failed")
-}
-
-impl<T: Pairing> From<PublicInputs> for SerializableInputs<T> {
-    fn from(src: PublicInputs) -> SerializableInputs<T> {
-        let si = src
-            .0
-            .iter()
-            .map(|n| {
-                if *n > BigUint::from_bytes_le(T::ScalarField::MODULUS.to_bytes_le().as_ref()) {
-                    panic!("Invalid input, lager than MODULUS")
-                }
-                T::ScalarField::from_le_bytes_mod_order(n.to_bytes_le().as_ref())
-            })
-            .collect();
-        SerializableInputs(si)
-    }
-}
-
-impl<T: Pairing> From<SerializableInputs<T>> for PublicInputs {
-    fn from(src: SerializableInputs<T>) -> PublicInputs {
-        let pi = src
-            .0
-            .iter()
-            .map(|&si| BigUint::from_bytes_le(si.into_bigint().to_bytes_le().as_ref()))
-            .collect();
-        PublicInputs(pi)
-    }
 }
 
 #[cfg(feature = "arkworks")]

--- a/cli/src/template/android/app/src/main/java/com/example/moproapp/FibonacciComponent.kt
+++ b/cli/src/template/android/app/src/main/java/com/example/moproapp/FibonacciComponent.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import uniffi.mopro.GenerateProofResult
+import uniffi.mopro.Halo2ProofResult
 import uniffi.mopro.generateHalo2Proof
 import uniffi.mopro.verifyHalo2Proof
 
@@ -25,8 +25,8 @@ fun FibonacciComponent() {
     var verifyingTime by remember { mutableStateOf("verifying time: ") }
     var valid by remember { mutableStateOf("valid:") }
     var res by remember {
-        mutableStateOf<GenerateProofResult>(
-            GenerateProofResult(proof = ByteArray(size = 0), inputs = ByteArray(size = 0))
+        mutableStateOf<Halo2ProofResult>(
+            Halo2ProofResult(proof = ByteArray(size = 0), inputs = ByteArray(size = 0))
         )
     }
 

--- a/cli/src/template/android/app/src/main/java/com/example/moproapp/MultiplierComponent.kt
+++ b/cli/src/template/android/app/src/main/java/com/example/moproapp/MultiplierComponent.kt
@@ -10,7 +10,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.example.moproapp.getFilePathFromAssets
-import uniffi.mopro.GenerateProofResult
+import uniffi.mopro.CircomProofResult
+import uniffi.mopro.CircomProof
+import uniffi.mopro.G1
+import uniffi.mopro.G2
 import uniffi.mopro.generateCircomProof
 import uniffi.mopro.verifyCircomProof
 import uniffi.mopro.ProofLib
@@ -23,8 +26,17 @@ fun MultiplierComponent() {
     var valid by remember { mutableStateOf("valid:") }
     var output by remember { mutableStateOf("output:") }
     var res by remember {
-        mutableStateOf<GenerateProofResult>(
-            GenerateProofResult(proof = ByteArray(size = 0), inputs = ByteArray(size = 0))
+        mutableStateOf(
+            CircomProofResult(
+                proof = CircomProof(
+                    a = G1(x = "", y = "", z = null),
+                    b = G2(x = listOf(), y = listOf(), z = null),
+                    c = G1(x = "", y = "", z = null),
+                    protocol = "",
+                    curve = ""
+                ),
+                inputs = listOf() // inputs 現在是 List<String>
+            )
         )
     }
 
@@ -49,7 +61,7 @@ fun MultiplierComponent() {
         Button(
             onClick = {
                 val startTime = System.currentTimeMillis()
-                valid = "valid: " + verifyCircomProof(zkeyPath, res.proof, res.inputs, ProofLib.ARKWORKS).toString()
+                valid = "valid: " + verifyCircomProof(zkeyPath, res, ProofLib.ARKWORKS).toString()
                 val endTime = System.currentTimeMillis()
                 verifyingTime = "verifying time: " + (endTime - startTime).toString() + " ms"
                 output = "output: " + uniffi.mopro.toEthereumInputs(res.inputs)

--- a/cli/src/template/android/app/src/main/java/com/example/moproapp/MultiplierComponent.kt
+++ b/cli/src/template/android/app/src/main/java/com/example/moproapp/MultiplierComponent.kt
@@ -35,7 +35,7 @@ fun MultiplierComponent() {
                     protocol = "",
                     curve = ""
                 ),
-                inputs = listOf() // inputs 現在是 List<String>
+                inputs = listOf()
             )
         )
     }

--- a/cli/src/template/ios/MoproApp/ContentView.swift
+++ b/cli/src/template/ios/MoproApp/ContentView.swift
@@ -79,13 +79,11 @@ extension ContentView {
 
             // Expected outputs
             let outputs: [String] = [String(c), String(a)]
-            // let expectedOutput: [UInt8] = serializeOutputs(outputs)
             
             let start = CFAbsoluteTimeGetCurrent()
             
             // Generate Proof
             let generateProofResult = try generateCircomProof(zkeyPath: zkeyPath, circuitInputs: input_str, proofLib: ProofLib.arkworks)
-            // let public_inputs = serializeOutputs(generateProofResult.inputs)
             assert(!generateProofResult.proof.a.x.isEmpty, "Proof should not be empty")
             assert(outputs == generateProofResult.inputs, "Circuit outputs mismatch the expected outputs")
 

--- a/cli/src/template/ios/MoproApp/ContentView.swift
+++ b/cli/src/template/ios/MoproApp/ContentView.swift
@@ -79,15 +79,15 @@ extension ContentView {
 
             // Expected outputs
             let outputs: [String] = [String(c), String(a)]
-            let expectedOutput: [UInt8] = serializeOutputs(outputs)
+            // let expectedOutput: [UInt8] = serializeOutputs(outputs)
             
             let start = CFAbsoluteTimeGetCurrent()
             
             // Generate Proof
             let generateProofResult = try generateCircomProof(zkeyPath: zkeyPath, circuitInputs: input_str, proofLib: ProofLib.arkworks)
-            let public_inputs = serializeOutputs(generateProofResult.inputs)
+            // let public_inputs = serializeOutputs(generateProofResult.inputs)
             assert(!generateProofResult.proof.a.x.isEmpty, "Proof should not be empty")
-            assert(expectedOutput == public_inputs, "Circuit outputs mismatch the expected outputs")
+            assert(outputs == generateProofResult.inputs, "Circuit outputs mismatch the expected outputs")
 
             let end = CFAbsoluteTimeGetCurrent()
             let timeTaken = end - start
@@ -115,7 +115,7 @@ extension ContentView {
         do {
             let start = CFAbsoluteTimeGetCurrent()
             
-            let isValid = try verifyCircomProof(zkeyPath: zkeyPath, proofRet: CircomProofResult(proof: proof, inputs: inputs), proofLib: ProofLib.arkworks)
+            let isValid = try verifyCircomProof(zkeyPath: zkeyPath, proofResult: CircomProofResult(proof: proof, inputs: inputs), proofLib: ProofLib.arkworks)
             let end = CFAbsoluteTimeGetCurrent()
             let timeTaken = end - start
             

--- a/mopro-ffi/src/circom/ethereum.rs
+++ b/mopro-ffi/src/circom/ethereum.rs
@@ -1,4 +1,4 @@
-use crate::CircomProof;
+use crate::{CircomProof, G1, G2};
 use ark_bn254::{Bn254, Fq, Fq2, Fr, G1Affine, G2Affine};
 use circom_prover::prover::{
     ethereum::{self, CURVE_BN254, PROTOCOL_GROTH16},
@@ -6,18 +6,6 @@ use circom_prover::prover::{
 };
 use num_bigint::BigUint;
 use std::str::FromStr;
-
-#[derive(Debug, Clone, Default)]
-pub struct G1 {
-    pub x: String,
-    pub y: String,
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct G2 {
-    pub x: Vec<String>,
-    pub y: Vec<String>,
-}
 
 #[derive(Debug, Clone, Default)]
 pub struct ProofCalldata {
@@ -32,14 +20,17 @@ pub fn to_ethereum_proof(proof: CircomProof) -> ProofCalldata {
     let a = G1 {
         x: proof.a.x.to_string(),
         y: proof.a.y.to_string(),
+        z: None,
     };
     let b = G2 {
         x: proof.b.x.iter().map(|x| x.to_string()).collect(),
         y: proof.b.y.iter().map(|x| x.to_string()).collect(),
+        z: None,
     };
     let c = G1 {
         x: proof.c.x.to_string(),
         y: proof.c.y.to_string(),
+        z: None,
     };
     ProofCalldata { a, b, c }
 }

--- a/mopro-ffi/src/circom/ethereum.rs
+++ b/mopro-ffi/src/circom/ethereum.rs
@@ -1,7 +1,7 @@
 use crate::{CircomProof, G1, G2};
 use ark_bn254::{Bn254, Fq, Fq2, Fr, G1Affine, G2Affine};
 use circom_prover::prover::{
-    ethereum::{self, CURVE_BN254, PROTOCOL_GROTH16},
+    circom::{self, CURVE_BN254, PROTOCOL_GROTH16},
     serialization::{self, deserialize_inputs, SerializableInputs},
 };
 use num_bigint::BigUint;
@@ -38,7 +38,7 @@ pub fn to_ethereum_proof(proof: CircomProof) -> ProofCalldata {
 // Only supports bn254 for now
 pub fn to_ethereum_inputs(inputs: Vec<u8>) -> Vec<String> {
     let deserialized_inputs = deserialize_inputs::<Bn254>(inputs);
-    let inputs = ethereum::Inputs::from(&deserialized_inputs.0[..]);
+    let inputs = circom::Inputs::from(&deserialized_inputs.0[..]);
     let inputs = inputs.0.iter().map(|x| x.to_string()).collect();
     inputs
 }
@@ -49,7 +49,7 @@ pub fn from_ethereum_inputs(inputs: Vec<String>) -> Vec<u8> {
         .iter()
         .map(|x| BigUint::from_str(x).unwrap())
         .collect::<Vec<BigUint>>();
-    let fr_inputs: Vec<Fr> = ethereum::Inputs(inputs).into();
+    let fr_inputs: Vec<Fr> = circom::Inputs(inputs).into();
     serialization::serialize_inputs(&SerializableInputs::<Bn254>(fr_inputs))
 }
 
@@ -58,11 +58,11 @@ pub fn from_ethereum_proof(proof: ProofCalldata) -> CircomProof {
     let a_x = Fq::from_str(&proof.a.x).unwrap();
     let a_y = Fq::from_str(&proof.a.y).unwrap();
     let a = G1Affine::new_unchecked(a_x, a_y);
-    let a_biguint = ethereum::G1::from_bn254(&a);
+    let a_biguint = circom::G1::from_bn254(&a);
     let c_x = Fq::from_str(&proof.c.x).unwrap();
     let c_y = Fq::from_str(&proof.c.y).unwrap();
     let c = G1Affine::new_unchecked(c_x, c_y);
-    let c_biguint = ethereum::G1::from_bn254(&c);
+    let c_biguint = circom::G1::from_bn254(&c);
     let b1_x = Fq::from_str(&proof.b.x[0]).unwrap();
     let b1_y = Fq::from_str(&proof.b.x[1]).unwrap();
     let b1 = Fq2::new(b1_x, b1_y);
@@ -70,7 +70,7 @@ pub fn from_ethereum_proof(proof: ProofCalldata) -> CircomProof {
     let b2_y = Fq::from_str(&proof.b.y[1]).unwrap();
     let b2 = Fq2::new(b2_x, b2_y);
     let b = G2Affine::new_unchecked(b1, b2);
-    let b_biguint = ethereum::G2::from_bn254(&b);
+    let b_biguint = circom::G2::from_bn254(&b);
     CircomProof {
         a: a_biguint.into(),
         b: b_biguint.into(),
@@ -88,7 +88,7 @@ mod tests {
     mod ethereum {
         use super::*;
         use circom_prover::prover::{
-            ethereum::{
+            circom::{
                 Proof as CircomProverProof, CURVE_BN254, G1 as CircomProverG1,
                 G2 as CircomProverG2, PROTOCOL_GROTH16,
             },

--- a/mopro-ffi/src/circom/mod.rs
+++ b/mopro-ffi/src/circom/mod.rs
@@ -67,29 +67,29 @@ macro_rules! circom_app {
                 .map_err(|e| <$err>::CircomError(format!("Verification error: {}", e)))
         }
 
-        // #[allow(dead_code)]
-        // #[cfg_attr(not(disable_uniffi_export), uniffi::export)]
-        // fn to_ethereum_proof(proof: $proof) -> $proof_call_data {
-        //     mopro_ffi::to_ethereum_proof(proof.into()).into()
-        // }
+        #[allow(dead_code)]
+        #[cfg_attr(not(disable_uniffi_export), uniffi::export)]
+        fn to_ethereum_proof(proof: $proof) -> $proof_call_data {
+            mopro_ffi::to_ethereum_proof(proof.into()).into()
+        }
 
-        // #[allow(dead_code)]
-        // #[cfg_attr(not(disable_uniffi_export), uniffi::export)]
-        // fn to_ethereum_inputs(inputs: Vec<u8>) -> Vec<String> {
-        //     mopro_ffi::to_ethereum_inputs(inputs)
-        // }
+        #[allow(dead_code)]
+        #[cfg_attr(not(disable_uniffi_export), uniffi::export)]
+        fn to_ethereum_inputs(inputs: Vec<u8>) -> Vec<String> {
+            mopro_ffi::to_ethereum_inputs(inputs)
+        }
 
-        // #[allow(dead_code)]
-        // #[cfg_attr(not(disable_uniffi_export), uniffi::export)]
-        // fn from_ethereum_proof(proof: $proof_call_data) -> $proof {
-        //     mopro_ffi::from_ethereum_proof(proof.into()).into()
-        // }
+        #[allow(dead_code)]
+        #[cfg_attr(not(disable_uniffi_export), uniffi::export)]
+        fn from_ethereum_proof(proof: $proof_call_data) -> $proof {
+            mopro_ffi::from_ethereum_proof(proof.into()).into()
+        }
 
-        // #[allow(dead_code)]
-        // #[cfg_attr(not(disable_uniffi_export), uniffi::export)]
-        // fn from_ethereum_inputs(inputs: Vec<String>) -> Vec<u8> {
-        //     mopro_ffi::from_ethereum_inputs(inputs)
-        // }
+        #[allow(dead_code)]
+        #[cfg_attr(not(disable_uniffi_export), uniffi::export)]
+        fn from_ethereum_inputs(inputs: Vec<String>) -> Vec<u8> {
+            mopro_ffi::from_ethereum_inputs(inputs)
+        }
     };
 }
 

--- a/mopro-ffi/src/circom/mod.rs
+++ b/mopro-ffi/src/circom/mod.rs
@@ -29,7 +29,7 @@ macro_rules! circom_app {
         ) -> Result<$result, $err> {
             let chosen_proof_lib = match proof_lib {
                 <$proof_lib>::Arkworks => mopro_ffi::prover::ProofLib::Arkworks,
-                <$proof_lib>::RapidSnark => mopro_ffi::prover::ProofLib::RapidSnark,
+                <$proof_lib>::Rapidsnark => mopro_ffi::prover::ProofLib::Rapidsnark,
             };
             let name = match std::path::Path::new(zkey_path.as_str()).file_name() {
                 Some(v) => v,
@@ -56,14 +56,14 @@ macro_rules! circom_app {
         #[cfg_attr(not(disable_uniffi_export), uniffi::export)]
         fn verify_circom_proof(
             zkey_path: String,
-            proof_ret: $result,
+            proof_result: $result,
             proof_lib: $proof_lib,
         ) -> Result<bool, $err> {
             let chosen_proof_lib = match proof_lib {
                 <$proof_lib>::Arkworks => mopro_ffi::prover::ProofLib::Arkworks,
-                <$proof_lib>::RapidSnark => mopro_ffi::prover::ProofLib::RapidSnark,
+                <$proof_lib>::Rapidsnark => mopro_ffi::prover::ProofLib::Rapidsnark,
             };
-            mopro_ffi::verify_circom_proof(chosen_proof_lib, zkey_path, proof_ret.into())
+            mopro_ffi::verify_circom_proof(chosen_proof_lib, zkey_path, proof_result.into())
                 .map_err(|e| <$err>::CircomError(format!("Verification error: {}", e)))
         }
 

--- a/mopro-ffi/src/circom/mod.rs
+++ b/mopro-ffi/src/circom/mod.rs
@@ -5,7 +5,7 @@ use crate::{CircomProof, CircomProofResult, G1, G2};
 use anyhow::{bail, Ok, Result};
 use circom_prover::{
     prover::{
-        ethereum::{
+        circom::{
             Proof as CircomProverProof, CURVE_BLS12_381, CURVE_BN254, G1 as CircomProverG1,
             G2 as CircomProverG2,
         },
@@ -36,12 +36,8 @@ macro_rules! circom_app {
                 }
             };
             let witness_fn = get_circom_wtns_fn(name.to_str().unwrap())?;
-            let chosen_proof_lib = match proof_lib {
-                <$proof_lib>::Arkworks => mopro_ffi::prover::ProofLib::Arkworks,
-                <$proof_lib>::Rapidsnark => mopro_ffi::prover::ProofLib::RapidSnark,
-            };
             let result = mopro_ffi::generate_circom_proof_wtns(
-                chosen_proof_lib,
+                proof_lib,
                 zkey_path,
                 circuit_inputs,
                 witness_fn,
@@ -59,11 +55,7 @@ macro_rules! circom_app {
             proof_ret: $result,
             proof_lib: $proof_lib,
         ) -> Result<bool, $err> {
-            let chosen_proof_lib = match proof_lib {
-                <$proof_lib>::Arkworks => mopro_ffi::prover::ProofLib::Arkworks,
-                <$proof_lib>::Rapidsnark => mopro_ffi::prover::ProofLib::RapidSnark,
-            };
-            mopro_ffi::verify_circom_proof(chosen_proof_lib, zkey_path, proof_ret)
+            mopro_ffi::verify_circom_proof(proof_lib, zkey_path, proof_ret)
                 .map_err(|e| <$err>::CircomError(format!("Verification error: {}", e)))
         }
 
@@ -286,7 +278,7 @@ mod tests {
                 mopro_ffi::CircomProof,
                 mopro_ffi::ProofCalldata,
                 mopro_ffi::MoproError,
-                mopro_ffi::ProofLib
+                circom_prover::prover::ProofLib
             );
 
             set_circom_circuits! {
@@ -308,7 +300,7 @@ mod tests {
             let result = generate_circom_proof(
                 ZKEY_PATH.to_string(),
                 input_str,
-                mopro_ffi::ProofLib::Arkworks,
+                circom_prover::prover::ProofLib::Arkworks,
             );
 
             assert!(result.is_ok());
@@ -346,7 +338,7 @@ mod tests {
                 mopro_ffi::CircomProof,
                 mopro_ffi::ProofCalldata,
                 mopro_ffi::MoproError,
-                mopro_ffi::ProofLib
+                circom_prover::prover::ProofLib
             );
 
             set_circom_circuits! {
@@ -368,7 +360,7 @@ mod tests {
             let result = generate_circom_proof(
                 ZKEY_PATH.to_string(),
                 input_str,
-                mopro_ffi::ProofLib::Arkworks,
+                circom_prover::prover::ProofLib::Arkworks,
             );
 
             assert!(result.is_ok());

--- a/mopro-ffi/src/circom/mod.rs
+++ b/mopro-ffi/src/circom/mod.rs
@@ -210,7 +210,7 @@ impl From<CircomProverG1> for G1 {
         G1 {
             x: g1.x.to_string(),
             y: g1.y.to_string(),
-            z: g1.z.to_string(),
+            z: Some(g1.z.to_string()),
         }
     }
 }
@@ -220,7 +220,11 @@ impl From<G1> for CircomProverG1 {
         CircomProverG1 {
             x: BigUint::from_str(g1.x.as_str()).unwrap(),
             y: BigUint::from_str(g1.y.as_str()).unwrap(),
-            z: BigUint::from_str(g1.z.as_str()).unwrap(),
+            z: BigUint::from_str(
+                g1.z.expect("coord z is not assigned correctly in G1.")
+                    .as_str(),
+            )
+            .unwrap(),
         }
     }
 }
@@ -229,7 +233,7 @@ impl From<CircomProverG2> for G2 {
     fn from(g2: CircomProverG2) -> Self {
         let x = vec![g2.x[0].to_string(), g2.x[1].to_string()];
         let y = vec![g2.y[0].to_string(), g2.y[1].to_string()];
-        let z = vec![g2.z[0].to_string(), g2.z[1].to_string()];
+        let z = Some(vec![g2.z[0].to_string(), g2.z[1].to_string()]);
         G2 { x, y, z }
     }
 }
@@ -245,7 +249,8 @@ impl From<G2> for CircomProverG2 {
                 .map(|p| BigUint::from_str(p.as_str()).unwrap())
                 .collect::<Vec<BigUint>>();
         let z =
-            g2.z.iter()
+            g2.z.expect("coord z are not assigned correctly in G2")
+                .iter()
                 .map(|p| BigUint::from_str(p.as_str()).unwrap())
                 .collect::<Vec<BigUint>>();
         CircomProverG2 {

--- a/mopro-ffi/src/halo2/mod.rs
+++ b/mopro-ffi/src/halo2/mod.rs
@@ -16,7 +16,7 @@ macro_rules! halo2_app {
             let proving_fn = get_halo2_proving_circuit(name.to_str().unwrap())
                 .map_err(|e| <$err>::Halo2Error(format!("error getting proving circuit: {}", e)))?;
             let result = proving_fn(&srs_path, &pk_path, circuit_inputs)
-                .map(|(proof, inputs)| mopro_ffi::GenerateProofResult { proof, inputs })
+                .map(|(proof, inputs)| mopro_ffi::Halo2ProofResult { proof, inputs })
                 .map_err(|e| mopro_ffi::MoproError::Halo2Error(format!("halo2 error: {}", e)))
                 .unwrap();
 
@@ -129,7 +129,7 @@ mod test {
 
     #[test]
     fn test_generate_and_verify_plonk_proof() {
-        halo2_app!(mopro_ffi::GenerateProofResult, mopro_ffi::MoproError);
+        halo2_app!(mopro_ffi::Halo2ProofResult, mopro_ffi::MoproError);
 
         set_halo2_circuits! {
             ("plonk_fibonacci_pk.bin", plonk_fibonacci::prove, "plonk_fibonacci_vk.bin", plonk_fibonacci::verify),
@@ -161,7 +161,7 @@ mod test {
 
     #[test]
     fn test_generate_and_verify_hyperplonk_proof() {
-        halo2_app!(mopro_ffi::GenerateProofResult, mopro_ffi::MoproError);
+        halo2_app!(mopro_ffi::Halo2ProofResult, mopro_ffi::MoproError);
 
         set_halo2_circuits! {
             ("hyperplonk_fibonacci_pk.bin", hyperplonk_fibonacci::prove, "hyperplonk_fibonacci_vk.bin", hyperplonk_fibonacci::verify),
@@ -193,7 +193,7 @@ mod test {
 
     #[test]
     fn test_generate_and_verify_gemini_proof() {
-        halo2_app!(mopro_ffi::GenerateProofResult, mopro_ffi::MoproError);
+        halo2_app!(mopro_ffi::Halo2ProofResult, mopro_ffi::MoproError);
 
         set_halo2_circuits! {
             ("gemini_fibonacci_pk.bin", gemini_fibonacci::prove, "gemini_fibonacci_vk.bin", gemini_fibonacci::verify),

--- a/mopro-ffi/src/lib.rs
+++ b/mopro-ffi/src/lib.rs
@@ -228,8 +228,17 @@ macro_rules! app {
         impl From<mopro_ffi::CircomProofResult> for CircomProofResult {
             fn from(result: mopro_ffi::CircomProofResult) -> Self {
                 Self {
-                    proof: result.proof,
+                    proof: result.proof.into(),
                     inputs: result.inputs,
+                }
+            }
+        }
+
+        impl Into<mopro_ffi::CircomProofResult> for CircomProofResult {
+            fn into(self) -> mopro_ffi::CircomProofResult {
+                mopro_ffi::CircomProofResult {
+                    proof: self.proof.into(),
+                    inputs: self.inputs,
                 }
             }
         }
@@ -258,25 +267,49 @@ macro_rules! app {
         }
 
         impl From<mopro_ffi::CircomProof> for CircomProof {
-            fn from(result: mopro_ffi::CircomProof) -> Self {
+            fn from(proof: mopro_ffi::CircomProof) -> Self {
                 CircomProof {
                     a: G1 {
-                        x: result.a.x,
-                        y: result.a.y,
-                        z: result.a.z,
+                        x: proof.a.x,
+                        y: proof.a.y,
+                        z: proof.a.z,
                     },
                     b: G2 {
-                        x: result.b.x,
-                        y: result.b.y,
-                        z: result.b.z,
+                        x: proof.b.x,
+                        y: proof.b.y,
+                        z: proof.b.z,
                     },
                     c: G1 {
-                        x: result.c.x,
-                        y: result.c.y,
-                        z: result.c.z,
+                        x: proof.c.x,
+                        y: proof.c.y,
+                        z: proof.c.z,
                     },
-                    protocol: result.protocol,
-                    curve: result.curve,
+                    protocol: proof.protocol,
+                    curve: proof.curve,
+                }
+            }
+        }
+
+        impl Into<mopro_ffi::CircomProof> for CircomProof {
+            fn into(self) -> mopro_ffi::CircomProof {
+                mopro_ffi::CircomProof {
+                    a: mopro_ffi::G1 {
+                        x: self.a.x,
+                        y: self.a.y,
+                        z: self.a.z,
+                    },
+                    b: mopro_ffi::G2 {
+                        x: self.b.x,
+                        y: self.b.y,
+                        z: self.b.z,
+                    },
+                    c: mopro_ffi::G1 {
+                        x: self.c.x,
+                        y: self.c.y,
+                        z: self.c.z,
+                    },
+                    protocol: self.protocol,
+                    curve: self.curve,
                 }
             }
         }
@@ -290,6 +323,28 @@ macro_rules! app {
             pub a: G1,
             pub b: G2,
             pub c: G1,
+        }
+
+        impl From<mopro_ffi::ProofCalldata> for ProofCalldata {
+            fn from(proof: mopro_ffi::ProofCalldata) -> Self {
+                ProofCalldata {
+                    a: G1 {
+                        x: proof.a.x,
+                        y: proof.a.y,
+                        z: None,
+                    },
+                    b: G2 {
+                        x: proof.b.x,
+                        y: proof.b.y,
+                        z: None,
+                    },
+                    c: G1 {
+                        x: proof.c.x,
+                        y: proof.c.y,
+                        z: None,
+                    },
+                }
+            }
         }
 
         impl Into<mopro_ffi::ProofCalldata> for ProofCalldata {
@@ -319,7 +374,7 @@ macro_rules! app {
         pub enum ProofLib {
             #[default]
             Arkworks,
-            Rapidsnark,
+            RapidSnark,
         }
 
         mopro_ffi::circom_app!(

--- a/mopro-ffi/src/lib.rs
+++ b/mopro-ffi/src/lib.rs
@@ -32,7 +32,7 @@ macro_rules! circom_app {
 
         fn verify_circom_proof(
             zkey_path: String,
-            proof_ret: $result,
+            proof_result: $result,
             proof_lib: $proof_lib,
         ) -> Result<bool, $err> {
             panic!("Circom is not enabled in this build. Please pass `circom` feature to `mopro-ffi` to enable Circom.")
@@ -127,16 +127,6 @@ pub struct Halo2ProofResult {
     pub proof: Vec<u8>,
     pub inputs: Vec<u8>,
 }
-
-//
-// Proof Libs
-//
-// #[derive(Debug, Clone, Default)]
-// pub enum ProofLib {
-//     #[default]
-//     Arkworks,
-//     Rapidsnark,
-// }
 
 /// This macro is used to setup the Mopro FFI library
 /// It should be included in the `lib.rs` file of the project
@@ -374,7 +364,7 @@ macro_rules! app {
         pub enum ProofLib {
             #[default]
             Arkworks,
-            RapidSnark,
+            Rapidsnark,
         }
 
         mopro_ffi::circom_app!(

--- a/test-e2e/android/app/src/main/java/com/mopro/mopro_app/FibonacciComponent.kt
+++ b/test-e2e/android/app/src/main/java/com/mopro/mopro_app/FibonacciComponent.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import uniffi.mopro.GenerateProofResult
+import uniffi.mopro.Halo2ProofResult
 import uniffi.mopro.generateHalo2Proof
 import uniffi.mopro.verifyHalo2Proof
 
@@ -26,8 +26,8 @@ fun FibonacciComponent() {
     var verifyingTime by remember { mutableStateOf("verifying time: ") }
     var valid by remember { mutableStateOf("valid:") }
     var res by remember {
-        mutableStateOf<GenerateProofResult>(
-            GenerateProofResult(proof = ByteArray(size = 0), inputs = ByteArray(size = 0))
+        mutableStateOf<Halo2ProofResult>(
+            Halo2ProofResult(proof = ByteArray(size = 0), inputs = ByteArray(size = 0))
         )
     }
 

--- a/test-e2e/android/app/src/main/java/com/mopro/mopro_app/MultiplierComponent.kt
+++ b/test-e2e/android/app/src/main/java/com/mopro/mopro_app/MultiplierComponent.kt
@@ -11,7 +11,10 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.mopro.mopro_app.getFilePathFromAssets
-import uniffi.mopro.GenerateProofResult
+import uniffi.mopro.CircomProofResult
+import uniffi.mopro.CircomProof
+import uniffi.mopro.G1
+import uniffi.mopro.G2
 import uniffi.mopro.ProofLib
 import uniffi.mopro.generateCircomProof
 import uniffi.mopro.verifyCircomProof
@@ -23,8 +26,17 @@ fun MultiplierComponent() {
     var valid by remember { mutableStateOf("valid:") }
     var output by remember { mutableStateOf("output:") }
     var res by remember {
-        mutableStateOf<GenerateProofResult>(
-            GenerateProofResult(proof = ByteArray(size = 0), inputs = ByteArray(size = 0))
+        mutableStateOf(
+            CircomProofResult(
+                proof = CircomProof(
+                    a = G1(x = "", y = "", z = null),
+                    b = G2(x = listOf(), y = listOf(), z = null),
+                    c = G1(x = "", y = "", z = null),
+                    protocol = "",
+                    curve = ""
+                ),
+                inputs = listOf() // inputs 現在是 List<String>
+            )
         )
     }
 
@@ -48,15 +60,11 @@ fun MultiplierComponent() {
         ) { Text(text = "generate proof") }
         Button(
             onClick = {
-                val ethereumProof = uniffi.mopro.toEthereumProof(res.proof)
-                val ethereumInputs = uniffi.mopro.toEthereumInputs(res.inputs)
-                val moproProof = uniffi.mopro.fromEthereumProof(ethereumProof)
-                val moproInputs = uniffi.mopro.fromEthereumInputs(ethereumInputs)
                 val startTime = System.currentTimeMillis()
-                valid = "valid: " + verifyCircomProof(zkeyPath, moproProof, moproInputs, ProofLib.ARKWORKS).toString()
+                valid = "valid: " + verifyCircomProof(zkeyPath, res, ProofLib.ARKWORKS).toString()
                 val endTime = System.currentTimeMillis()
                 verifyingTime = "verifying time: " + (endTime - startTime).toString() + " ms"
-                output = "output: " + uniffi.mopro.toEthereumInputs(res.inputs)
+                output = "output: " + res.inputs
             },
             modifier = Modifier.padding(top = 120.dp).testTag("circomVerifyProofButton")
         ) { Text(text = "verify proof") }

--- a/test-e2e/android/app/src/main/java/com/mopro/mopro_app/MultiplierComponent.kt
+++ b/test-e2e/android/app/src/main/java/com/mopro/mopro_app/MultiplierComponent.kt
@@ -35,7 +35,7 @@ fun MultiplierComponent() {
                     protocol = "",
                     curve = ""
                 ),
-                inputs = listOf() // inputs 現在是 List<String>
+                inputs = listOf()
             )
         )
     }

--- a/test-e2e/ios/mopro-test/ContentView.swift
+++ b/test-e2e/ios/mopro-test/ContentView.swift
@@ -41,8 +41,8 @@ struct ContentView: View {
     @State private var isHalo2VerifyButtonEnabled = false
     @State private var isAshlangroveButtonEnabled = true
     @State private var isAshlangVerifyButtonEnabled = false
-    @State private var generatedCircomProof: Data?
-    @State private var circomPublicInputs: Data?
+    @State private var generatedCircomProof: CircomProof?
+    @State private var circomPublicInputs: [String]?
     @State private var generatedHalo2Proof: Data?
     @State private var halo2PublicInputs: Data?
     private let zkeyPath = Bundle.main.path(forResource: "multiplier2_final", ofType: "zkey")!
@@ -89,14 +89,14 @@ extension ContentView {
             
             // Generate Proof
             let generateProofResult = try generateCircomProof(zkeyPath: zkeyPath, circuitInputs: input_str, proofLib: ProofLib.arkworks)
-            assert(!generateProofResult.proof.isEmpty, "Proof should not be empty")
-            assert(Data(expectedOutput) == generateProofResult.inputs, "Circuit outputs mismatch the expected outputs")
+            let public_inputs = serializeOutputs(generateProofResult.inputs)
+            assert(!generateProofResult.proof.a.x.isEmpty, "Proof should not be empty")
+            assert(expectedOutput == public_inputs, "Circuit outputs mismatch the expected outputs")
             
             let end = CFAbsoluteTimeGetCurrent()
             let timeTaken = end - start
             
             // Store the generated proof and public inputs for later verification
-
             generatedCircomProof = generateProofResult.proof
             circomPublicInputs = generateProofResult.inputs
             
@@ -117,22 +117,17 @@ extension ContentView {
         
         textViewText += "Verifying Circom proof... "
         do {
-            // Convert proof to Ethereum compatible proof
-            let ethereumProof = toEthereumProof(proof: proof)
-            let ethereumInputs = toEthereumInputs(inputs: inputs)
-            let moproProof = fromEthereumProof(proof: ethereumProof)
-            let moproInputs = fromEthereumInputs(inputs: ethereumInputs)
             let start = CFAbsoluteTimeGetCurrent()
             
-            let isValid = try verifyCircomProof(zkeyPath: zkeyPath, proof: moproProof, publicInput: moproInputs, proofLib: ProofLib.arkworks)
+            let isValid = try verifyCircomProof(zkeyPath: zkeyPath, proofRet: CircomProofResult(proof: proof, inputs: inputs), proofLib: ProofLib.arkworks)
             let end = CFAbsoluteTimeGetCurrent()
             let timeTaken = end - start
             
-            assert(ethereumProof.a.x.count > 0, "Proof should not be empty")
-            assert(ethereumInputs.count > 0, "Inputs should not be empty")
+            assert(proof.a.x.count > 0, "Proof should not be empty")
+            assert(inputs.count > 0, "Inputs should not be empty")
             
-            print("Ethereum Proof: \(ethereumProof)\n")
-            print("Ethereum Inputs: \(ethereumInputs)\n")
+            print("Ethereum Proof: \(proof)\n")
+            print("Ethereum Inputs: \(inputs)\n")
             
             if isValid {
                 textViewText += "\(String(format: "%.3f", timeTaken))s 2️⃣\n"

--- a/test-e2e/ios/mopro-test/ContentView.swift
+++ b/test-e2e/ios/mopro-test/ContentView.swift
@@ -83,15 +83,15 @@ extension ContentView {
             
             // Expected outputs
             let outputs: [String] = [String(c), String(a)]
-            let expectedOutput: [UInt8] = serializeOutputs(outputs)
+            // let expectedOutput: [UInt8] = serializeOutputs(outputs)
             
             let start = CFAbsoluteTimeGetCurrent()
             
             // Generate Proof
             let generateProofResult = try generateCircomProof(zkeyPath: zkeyPath, circuitInputs: input_str, proofLib: ProofLib.arkworks)
-            let public_inputs = serializeOutputs(generateProofResult.inputs)
+            // let public_inputs = serializeOutputs(generateProofResult.inputs)
             assert(!generateProofResult.proof.a.x.isEmpty, "Proof should not be empty")
-            assert(expectedOutput == public_inputs, "Circuit outputs mismatch the expected outputs")
+            assert(outputs == generateProofResult.inputs, "Circuit outputs mismatch the expected outputs")
             
             let end = CFAbsoluteTimeGetCurrent()
             let timeTaken = end - start
@@ -119,7 +119,7 @@ extension ContentView {
         do {
             let start = CFAbsoluteTimeGetCurrent()
             
-            let isValid = try verifyCircomProof(zkeyPath: zkeyPath, proofRet: CircomProofResult(proof: proof, inputs: inputs), proofLib: ProofLib.arkworks)
+            let isValid = try verifyCircomProof(zkeyPath: zkeyPath, proofResult: CircomProofResult(proof: proof, inputs: inputs), proofLib: ProofLib.arkworks)
             let end = CFAbsoluteTimeGetCurrent()
             let timeTaken = end - start
             

--- a/test-e2e/ios/mopro-test/ContentView.swift
+++ b/test-e2e/ios/mopro-test/ContentView.swift
@@ -83,13 +83,11 @@ extension ContentView {
             
             // Expected outputs
             let outputs: [String] = [String(c), String(a)]
-            // let expectedOutput: [UInt8] = serializeOutputs(outputs)
             
             let start = CFAbsoluteTimeGetCurrent()
             
             // Generate Proof
             let generateProofResult = try generateCircomProof(zkeyPath: zkeyPath, circuitInputs: input_str, proofLib: ProofLib.arkworks)
-            // let public_inputs = serializeOutputs(generateProofResult.inputs)
             assert(!generateProofResult.proof.a.x.isEmpty, "Proof should not be empty")
             assert(outputs == generateProofResult.inputs, "Circuit outputs mismatch the expected outputs")
             

--- a/test-e2e/tests/bindings/test_circom_keccak.kts
+++ b/test-e2e/tests/bindings/test_circom_keccak.kts
@@ -266,7 +266,7 @@ try {
 
     var generateProofResult = generateCircomProof(zkeyPath, inputs.toString(), ProofLib.ARKWORKS)
     assert(generateProofResult.proof.size > 0) { "Proof is empty" }
-    var isValid = verifyCircomProof(zkeyPath, generateProofResult.proof, generateProofResult.inputs, ProofLib.ARKWORKS)
+    var isValid = verifyCircomProof(zkeyPath, generateProofResult, ProofLib.ARKWORKS)
     assert(isValid) { "Proof is invalid" }
 } catch (e: Exception) {
     println(e)

--- a/test-e2e/tests/bindings/test_circom_keccak.swift
+++ b/test-e2e/tests/bindings/test_circom_keccak.swift
@@ -64,16 +64,15 @@ do {
   // Generate Proof
   let generateProofResult = try generateCircomProof(
     zkeyPath: zkeyPath, circuitInputs: input_str, proofLib: ProofLib.arkworks)
-  assert(!generateProofResult.proof.isEmpty, "Proof should not be empty")
+  assert(!generateProofResult.proof.a.x.isEmpty, "Proof should not be empty")
 
   // Verify Proof
   assert(
     Data(expectedOutput) == generateProofResult.inputs,
     "Circuit outputs mismatch the expected outputs")
 
-  let isValid = try verifyCircomProof(
-    zkeyPath: zkeyPath, proof: generateProofResult.proof, publicInput: generateProofResult.inputs,
-    proofLib: ProofLib.arkworks)
+  let isValid = 
+    try verifyCircomProof(zkeyPath: zkeyPath, proofRet: generateProofResult, proofLib: ProofLib.arkworks)
   assert(isValid, "Proof verification should succeed")
 
 } catch let error as MoproError {

--- a/test-e2e/tests/bindings/test_circom_keccak.swift
+++ b/test-e2e/tests/bindings/test_circom_keccak.swift
@@ -72,7 +72,7 @@ do {
     "Circuit outputs mismatch the expected outputs")
 
   let isValid = 
-    try verifyCircomProof(zkeyPath: zkeyPath, proofRet: generateProofResult, proofLib: ProofLib.arkworks)
+    try verifyCircomProof(zkeyPath: zkeyPath, proofResult: generateProofResult, proofLib: ProofLib.arkworks)
   assert(isValid, "Proof verification should succeed")
 
 } catch let error as MoproError {

--- a/test-e2e/tests/bindings/test_circom_multiplier2.kts
+++ b/test-e2e/tests/bindings/test_circom_multiplier2.kts
@@ -10,14 +10,11 @@ try {
     assert(generateProofResult.proof.size > 0) { "Proof is empty" }
 
     // Verify proof
-    var isValid = verifyCircomProof(zkeyPath, generateProofResult.proof, generateProofResult.inputs, ProofLib.ARKWORKS)
+    var isValid = verifyCircomProof(zkeyPath, generateProofResult, ProofLib.ARKWORKS)
     assert(isValid) { "Proof is invalid" }
 
-    // Convert proof to Ethereum compatible proof
-    var convertProofResult = toEthereumProof(generateProofResult.proof)
-    var convertInputsResult = toEthereumInputs(generateProofResult.inputs)
-    assert(convertProofResult.a.x.isNotEmpty()) { "Proof is empty" }
-    assert(convertInputsResult.size > 0) { "Inputs are empty" }
+    assert(generateProofResult.proof.a.x.isNotEmpty()) { "Proof is empty" }
+    assert(generateProofResult.inputs.size > 0) { "Inputs are empty" }
 
 
 } catch (e: Exception) {

--- a/test-e2e/tests/bindings/test_circom_multiplier2.swift
+++ b/test-e2e/tests/bindings/test_circom_multiplier2.swift
@@ -47,23 +47,19 @@ do {
   // Generate Proof
   let generateProofResult = try generateCircomProof(
     zkeyPath: zkeyPath, circuitInputs: input_str, proofLib: ProofLib.arkworks)
-  assert(!generateProofResult.proof.isEmpty, "Proof should not be empty")
+  assert(!generateProofResult.proof.a.x.isEmpty, "Proof should not be empty")
 
   // Verify Proof
   assert(
     Data(expectedOutput) == generateProofResult.inputs,
     "Circuit outputs mismatch the expected outputs")
 
-  let isValid = try verifyCircomProof(
-    zkeyPath: zkeyPath, proof: generateProofResult.proof, publicInput: generateProofResult.inputs,
-    proofLib: ProofLib.arkworks)
+  let isValid = 
+    try verifyCircomProof(zkeyPath: zkeyPath, proof: generateProofResult, proofLib: ProofLib.arkworks)
   assert(isValid, "Proof verification should succeed")
 
-  // Convert proof to Ethereum compatible proof
-  let convertProofResult = toEthereumProof(proof: generateProofResult.proof)
-  let convertInputsResult = toEthereumInputs(inputs: generateProofResult.inputs)
-  assert(convertProofResult.a.x.count > 0, "Proof should not be empty")
-  assert(convertInputsResult.count > 0, "Inputs should not be empty")
+  assert(generateProofResult.proof.a.x.count > 0, "Proof should not be empty")
+  assert(generateProofResult.inputs.count > 0, "Inputs should not be empty")
 
 } catch let error as MoproError {
   print("MoproError: \(error)")

--- a/test-e2e/tests/bindings/test_circom_multiplier2_bls.kts
+++ b/test-e2e/tests/bindings/test_circom_multiplier2_bls.kts
@@ -10,7 +10,7 @@ try {
     assert(generateProofResult.proof.size > 0) { "Proof is empty" }
 
     // Verify proof
-    var isValid = verifyCircomProof(zkeyPath, generateProofResult.proof, generateProofResult.inputs, ProofLib.ARKWORKS)
+    var isValid = verifyCircomProof(zkeyPath, generateProofResult, ProofLib.ARKWORKS)
     assert(isValid) { "Proof is invalid" }
 
 

--- a/test-e2e/tests/bindings/test_circom_multiplier2_bls.swift
+++ b/test-e2e/tests/bindings/test_circom_multiplier2_bls.swift
@@ -47,16 +47,15 @@ do {
   // Generate Proof
   let generateProofResult = try generateCircomProof(
     zkeyPath: zkeyPath, circuitInputs: input_str, proofLib: ProofLib.arkworks)
-  assert(!generateProofResult.proof.isEmpty, "Proof should not be empty")
+  assert(!generateProofResult.proof.a.x.isEmpty, "Proof should not be empty")
 
   // Verify Proof
   assert(
     Data(expectedOutput) == generateProofResult.inputs,
     "Circuit outputs mismatch the expected outputs")
 
-  let isValid = try verifyCircomProof(
-    zkeyPath: zkeyPath, proof: generateProofResult.proof, publicInput: generateProofResult.inputs,
-    proofLib: ProofLib.arkworks)
+  let isValid = 
+    try verifyCircomProof(zkeyPath: zkeyPath, proofRet: generateProofResult, proofLib: ProofLib.arkworks)
   assert(isValid, "Proof verification should succeed")
 
 } catch let error as MoproError {

--- a/test-e2e/tests/bindings/test_circom_multiplier2_bls.swift
+++ b/test-e2e/tests/bindings/test_circom_multiplier2_bls.swift
@@ -55,7 +55,7 @@ do {
     "Circuit outputs mismatch the expected outputs")
 
   let isValid = 
-    try verifyCircomProof(zkeyPath: zkeyPath, proofRet: generateProofResult, proofLib: ProofLib.arkworks)
+    try verifyCircomProof(zkeyPath: zkeyPath, proofResult: generateProofResult, proofLib: ProofLib.arkworks)
   assert(isValid, "Proof verification should succeed")
 
 } catch let error as MoproError {


### PR DESCRIPTION
close #368 

In this PR, I kept `toEthereumProof`, `fromEthereumProof`, `toEthereumInputs`, `fromEthereumInputs`, just in case. This PR changed code a lot, I'll support BLS12-381 in the next PR.
