### PR TITLE
Fix Clippy warnings: manual_div_ceil, manual_contains, and use Error:…

### DIFF
--- a/circom-prover/src/prover/circom.rs
+++ b/circom-prover/src/prover/circom.rs
@@ -245,7 +245,7 @@ impl From<Proof> for ark_groth16::Proof<Bls12_381> {
 
 // Helper for converting a PrimeField to its BigUint representation for Ethereum compatibility
 fn biguint_to_point<F: PrimeField>(point: BigUint) -> F {
-    let buf_size: usize = ((F::MODULUS_BIT_SIZE + 7) / 8).try_into().unwrap(); // Rounds up the division
+    let buf_size: usize = F::MODULUS_BIT_SIZE.div_ceil(8).try_into().unwrap(); // Rounds up the division
     let mut buf = point.to_bytes_le();
     buf.resize(buf_size, 0u8);
     let bigint = F::BigInt::deserialize_uncompressed(&buf[..]).expect("always works");

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -44,7 +44,7 @@ impl AdapterSelector {
     }
 
     pub fn contains(&self, adapter: Adapter) -> bool {
-        self.adapters.iter().any(|p| *p == adapter)
+        self.adapters.contains(&adapter)
     }
 }
 
@@ -89,7 +89,7 @@ impl PlatformSelector {
     }
 
     pub fn contains(&self, platform: Platform) -> bool {
-        self.platforms.iter().any(|p| *p == platform)
+        self.platforms.contains(&platform)
     }
 
     pub fn select_archs(&self) -> HashMap<String, Vec<String>> {

--- a/mopro-ffi/src/app_config/android.rs
+++ b/mopro-ffi/src/app_config/android.rs
@@ -133,6 +133,6 @@ fn generate_android_bindings(dylib_path: &Path, binding_dir: &Path) -> anyhow::R
         ))?,
         true,
     )
-    .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?;
+    .map_err(|e| Error::other(e.to_string()))?;
     Ok(())
 }

--- a/mopro-ffi/src/app_config/ios.rs
+++ b/mopro-ffi/src/app_config/ios.rs
@@ -221,6 +221,6 @@ fn generate_ios_bindings(dylib_path: &Path, binding_dir: &Path) -> anyhow::Resul
         ))?,
         true,
     )
-    .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?;
+    .map_err(|e| Error::other(e.to_string()))?;
     Ok(())
 }


### PR DESCRIPTION
**Summary**
- Replaced manual `(F::MODULUS_BIT_SIZE + 7) / 8` with `F::MODULUS_BIT_SIZE.div_ceil(8)`, removing Clippy’s `manual_div_ceil` warning.
- Used `Vec<T>::contains(&item)` instead of `iter().any(...)` to fix `manual_contains`.
- Switched from `Error::new(ErrorKind::Other, ...)` to `Error::other(...)` to comply with Clippy’s `io_other_error` rule.

**Why**
- These changes resolve various Clippy warnings and make the code more idiomatic.
- Ensures better readability and potential performance improvements in some cases.

**Testing**
- Verified locally with `cargo clippy --all -- -D warnings` and everything passes without issues.
