### PR TITLE
chore: Fix typos

### DIFF
--- a/cli/src/constants.rs
+++ b/cli/src/constants.rs
@@ -103,26 +103,26 @@ pub enum AndroidArch {
     Aarch64Linux,
 }
 
-struct AndriodArchInfo {
+struct AndroidArchInfo {
     arch: AndroidArch,
     str: &'static str,
 }
 
 // Architecture strings need to be aligned with those in the mopro-ffi.
-const ANDROID_ARCHS: [AndriodArchInfo; 4] = [
-    AndriodArchInfo {
+const ANDROID_ARCHS: [AndroidArchInfo; 4] = [
+    AndroidArchInfo {
         arch: AndroidArch::X8664Linux,
         str: "x86_64-linux-android",
     },
-    AndriodArchInfo {
+    AndroidArchInfo {
         arch: AndroidArch::I686Linux,
         str: "i686-linux-android",
     },
-    AndriodArchInfo {
+    AndroidArchInfo {
         arch: AndroidArch::Armv7LinuxAbi,
         str: "armv7-linux-androideabi",
     },
-    AndriodArchInfo {
+    AndroidArchInfo {
         arch: AndroidArch::Aarch64Linux,
         str: "aarch64-linux-android",
     },

--- a/mopro-ffi/src/app_config/constants.rs
+++ b/mopro-ffi/src/app_config/constants.rs
@@ -117,26 +117,26 @@ pub enum AndroidArch {
     Aarch64Linux,
 }
 
-struct AndriodArchInfo {
+struct AndroidArchInfo {
     arch: AndroidArch,
     str: &'static str,
 }
 
 // Architecture strings need to be aligned with those in the CLI.
-const ANDROID_ARCHS: [AndriodArchInfo; 4] = [
-    AndriodArchInfo {
+const ANDROID_ARCHS: [AndroidArchInfo; 4] = [
+    AndroidArchInfo {
         arch: AndroidArch::X8664Linux,
         str: "x86_64-linux-android",
     },
-    AndriodArchInfo {
+    AndroidArchInfo {
         arch: AndroidArch::I686Linux,
         str: "i686-linux-android",
     },
-    AndriodArchInfo {
+    AndroidArchInfo {
         arch: AndroidArch::Armv7LinuxAbi,
         str: "armv7-linux-androideabi",
     },
-    AndriodArchInfo {
+    AndroidArchInfo {
         arch: AndroidArch::Aarch64Linux,
         str: "aarch64-linux-android",
     },

--- a/mopro-ffi/src/circom/mod.rs
+++ b/mopro-ffi/src/circom/mod.rs
@@ -127,7 +127,7 @@ pub fn generate_circom_proof_wtns(
     let (proof, public_inputs) = match ret.proof.curve.as_ref() {
         CURVE_BN254 => (ret.proof.into(), ret.pub_inputs.into()),
         CURVE_BLS12_381 => (ret.proof.into(), ret.pub_inputs.into()),
-        _ => bail!("Not uspported curve"),
+        _ => bail!("Not unsupported curve"),
     };
     Ok(CircomProofResult {
         proof,

--- a/test-e2e/src/lib.rs
+++ b/test-e2e/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(unexpected_cfgs)]
-// Explicitly declare funtion to avoid Uniffi's limitation
+// Explicitly declare function to avoid Uniffi's limitation
 use circom_prover::witness::WitnessFn;
 
 // First, configure the Mopro FFI library


### PR DESCRIPTION
Fix typos in 4 files

> [!IMPORTANT]
> This is potentially a breaking fix, since `AndriodArchInfo` is in UniFFI crate