### PR TITLE
chore: Add `typos` cli tool to CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,21 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  check-typos:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    steps:
+      - uses: actions/checkout@v4
+      - name: install requirements
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: wget
+          version: 1.0
+      - name: Spell Check Repo
+        uses: crate-ci/typos@v1.31.1
+        with:
+          config: ./_typos.toml
+
   clippy_check:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,4 @@
+[default]
+extend-ignore-re = [
+    "(?i).*groth.*"
+]


### PR DESCRIPTION
Add [`typos`](https://github.com/crate-ci/typos) CI step

This PR does these two changes:
* Adds one new config file `_typos.toml` (which was used to avoid false positives in #390 )
* Adds a new step in CI to find typos
