### PR TITLE
chore: Add `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+fail_fast: true
+default_install_hook_types: [pre-commit]
+default_stages: [pre-commit]
+repos:
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.31.1
+    hooks:
+      - id: typos
+  - repo: local
+    hooks:
+      - id: fmt
+        name: fmt
+        language: system
+        types: [file, rust]
+        entry: cargo fmt -- --check
+        pass_filenames: false
+
+      - id: clippy
+        name: clippy
+        language: system
+        types: [file, rust]
+        entry: cargo clippy --locked --all -- -D warnings # Use -D warnings option to ensure the job fails when encountering warnings
+        pass_filenames: false

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,4 @@
+[default]
+extend-ignore-re = [
+    "(?i).*groth.*"
+]


### PR DESCRIPTION
> [!NOTE]
> I've cherry-picked the first commit of #391 - adding of the `_typos.toml` file

> [!TIP]
> I did not add instruction to install `pre-commit` in README, since you put prerequisites in your 
> guide here: https://zkmopro.org/docs/prerequisites - so probably we ought to add instructions:
> 1. to install the `pre-commit` binary itself
> 2. to install the pre-commit config of this repo by running `pre-commit install`

This PR adds the wonderful [pre-commit](https://pre-commit.com) tool for pre-commit (and push) hooks.

I've added three steps - running:
* `typos` (see #391 )
* `cargo fmt`
* `cargo clippy`