### PR TITLE
Upgrade setup-java action to v4

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -297,7 +297,7 @@ jobs:
           path: test-e2e/MoproAndroidBindings
           key: ${{ github.sha }}-android-lib
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 17


### PR DESCRIPTION
Replace `actions/setup-java@v3` with `actions/setup-java@v4` [current release v4.4.0](https://github.com/actions/setup-java/releases/tag/v4.4.0) to move to the Node.js 20 runtime and keep receiving the latest fixes and features
