### PR TITLE
refactor: change ios and android fields in Config to Option<HashSet<S…

### DIFF
--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -6,6 +6,7 @@ use dialoguer::Confirm;
 use dialoguer::Select;
 use include_dir::include_dir;
 use include_dir::Dir;
+use std::collections::HashSet;
 use std::env;
 
 use crate::config::read_config;
@@ -148,6 +149,16 @@ pub fn build_project(arg_mode: &Option<String>, arg_platforms: &Option<Vec<Strin
 
     // Architecture selection for iOS or Android
     let selected_architectures = platform.select_archs(&mut config);
+    let mut ios_hash = HashSet::new();
+    let mut android_hash = HashSet::new();
+    for arch in selected_architectures.get("ios").unwrap() {
+        ios_hash.insert(arch.clone());
+    }
+    for arch in selected_architectures.get("android").unwrap() {
+        android_hash.insert(arch.clone());
+    }
+    config.ios = Some(ios_hash);
+    config.android = Some(android_hash);
     write_config(&config_path, &config)?;
 
     // Noir only supports `aarch64-apple-ios` and `aarch64-linux-android`

--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -6,7 +6,6 @@ use dialoguer::Confirm;
 use dialoguer::Select;
 use include_dir::include_dir;
 use include_dir::Dir;
-use std::collections::HashSet;
 use std::env;
 
 use crate::config::read_config;
@@ -149,16 +148,6 @@ pub fn build_project(arg_mode: &Option<String>, arg_platforms: &Option<Vec<Strin
 
     // Architecture selection for iOS or Android
     let selected_architectures = platform.select_archs(&mut config);
-    let mut ios_hash = HashSet::new();
-    let mut android_hash = HashSet::new();
-    for arch in selected_architectures.get("ios").unwrap() {
-        ios_hash.insert(arch.clone());
-    }
-    for arch in selected_architectures.get("android").unwrap() {
-        android_hash.insert(arch.clone());
-    }
-    config.ios = Some(ios_hash);
-    config.android = Some(android_hash);
     write_config(&config_path, &config)?;
 
     // Noir only supports `aarch64-apple-ios` and `aarch64-linux-android`

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -10,19 +10,22 @@ use crate::init::adapter::Adapter;
 // Storing user selections while iterating with mopro cli
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct Config {
-    pub(crate) target_adapters: HashSet<String>,
-    pub(crate) target_platforms: HashSet<String>,
+    pub(crate) target_adapters: Option<HashSet<String>>,
+    pub(crate) target_platforms: Option<HashSet<String>>,
     pub(crate) ios: Option<HashSet<String>>,
     pub(crate) android: Option<HashSet<String>>,
 }
 
 impl Config {
     pub fn adapter_eq(&self, adapter: Adapter) -> bool {
-        self.target_adapters == HashSet::from([String::from(adapter.as_str())])
+        self.target_adapters == Some(HashSet::from([String::from(adapter.as_str())]))
     }
-
     pub fn adapter_contains(&self, adapter: Adapter) -> bool {
-        self.target_adapters.contains(adapter.as_str())
+        if let Some(adapters) = &self.target_adapters {
+            adapters.contains(adapter.as_str())
+        } else {
+            false
+        }
     }
 }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -12,8 +12,8 @@ use crate::init::adapter::Adapter;
 pub struct Config {
     pub(crate) target_adapters: HashSet<String>,
     pub(crate) target_platforms: HashSet<String>,
-    pub(crate) ios: HashSet<String>,
-    pub(crate) android: HashSet<String>,
+    pub(crate) ios: Option<HashSet<String>>,
+    pub(crate) android: Option<HashSet<String>>,
 }
 
 impl Config {

--- a/cli/src/create.rs
+++ b/cli/src/create.rs
@@ -89,7 +89,13 @@ fn get_target_platforms_with_status() -> anyhow::Result<(Vec<String>, Vec<bool>)
                 let requires = [Platform::Ios, Platform::Android];
                 let missing: Vec<&str> = requires
                     .iter()
-                    .filter(|&req| !config.target_platforms.contains(req.as_str()))
+                    .filter(|&req| {
+                        if let Some(platforms) = &config.target_platforms {
+                            !platforms.contains(req.as_str())
+                        } else {
+                            false
+                        }
+                    })
                     .map(|r| r.as_str())
                     .collect();
 
@@ -106,9 +112,11 @@ fn get_target_platforms_with_status() -> anyhow::Result<(Vec<String>, Vec<bool>)
                 }
             }
             _ => {
-                if config.target_platforms.contains(framework_str) {
-                    items.push(framework_str.to_string());
-                    unselectable.push(false);
+                if let Some(platforms) = &config.target_platforms {
+                    if platforms.contains(framework_str) {
+                        items.push(framework_str.to_string());
+                        unselectable.push(false);
+                    }
                 } else {
                     items.push(format!(
                         "{:<12} - Require binding",

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -83,8 +83,8 @@ pub fn init_project(
         let default_config = Config {
             target_adapters: HashSet::new(),
             target_platforms: HashSet::new(),
-            ios: HashSet::new(),
-            android: HashSet::new(),
+            ios: Some(HashSet::new()),
+            android: Some(HashSet::new()),
         };
         write_config(&config_path, &default_config)?;
     }

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -81,8 +81,8 @@ pub fn init_project(
     // Check if the config file exists, if not create a default one
     if !config_path.exists() {
         let default_config = Config {
-            target_adapters: HashSet::new(),
-            target_platforms: HashSet::new(),
+            target_adapters: Some(HashSet::new()),
+            target_platforms: Some(HashSet::new()),
             ios: Some(HashSet::new()),
             android: Some(HashSet::new()),
         };
@@ -91,7 +91,10 @@ pub fn init_project(
     // Read & Write config for selected adapter
     let mut config = read_config(&config_path)?;
     for adapter in adapter_sel.adapters {
-        config.target_adapters.insert(adapter.as_str().to_string());
+        config
+            .target_adapters
+            .get_or_insert_with(HashSet::new)
+            .insert(adapter.as_str().to_string());
     }
     write_config(&config_path, &config)?;
 

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -100,9 +100,7 @@ impl PlatformSelector {
                     .iter()
                     .map(|&i| {
                         let arch = IosArch::from_idx(i).as_str().to_string();
-                        if let Some(ref mut ios) = config.ios {
-                            ios.insert(arch.clone());
-                        }
+                        config.ios.as_mut().unwrap().insert(arch.clone());
                         arch
                     })
                     .collect::<Vec<String>>();
@@ -129,9 +127,7 @@ impl PlatformSelector {
                     .iter()
                     .map(|&i| {
                         let arch = AndroidArch::from_idx(i).as_str().to_string();
-                        if let Some(ref mut android) = config.android {
-                            android.insert(arch.clone());
-                        }
+                        config.android.as_mut().unwrap().insert(arch.clone());
                         arch
                     })
                     .collect::<Vec<String>>();

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -33,12 +33,12 @@ impl PlatformSelector {
     pub fn select(config: &mut Config) -> Self {
         let platforms = Platform::all_strings();
         // defaults based on previous selections or all platforms
-        let defaults: Vec<bool> = if config.target_platforms.is_empty() {
-            vec![true; platforms.len()]
+        let defaults: Vec<bool> = if config.target_platforms.is_none() {
+            vec![false; platforms.len()]
         } else {
             platforms
                 .iter()
-                .map(|&platform| config.target_platforms.contains(platform))
+                .map(|&platform| config.target_platforms.as_ref().unwrap().contains(platform))
                 .collect()
         };
 
@@ -49,13 +49,17 @@ impl PlatformSelector {
             defaults,
         );
 
-        config.target_platforms.clear();
+        config.target_platforms = Some(HashSet::new());
+
         Self {
             platforms: platform_sel
                 .iter()
                 .map(|&i| {
                     let p = Platform::from_idx(i);
-                    config.target_platforms.insert(p.as_str().into());
+                    config
+                        .target_platforms
+                        .get_or_insert_with(HashSet::new)
+                        .insert(p.as_str().to_string());
                     p
                 })
                 .collect::<Vec<Platform>>(),

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -80,7 +80,7 @@ impl PlatformSelector {
                 // defaults based on previous selections if previous selections are not empty
                 // otherwise, selects all
                 let all_ios_archs = IosArch::all_strings();
-                let defaults: Vec<bool> = if !config.ios.is_some() {
+                let defaults: Vec<bool> = if config.ios.is_none() {
                     vec![true; all_ios_archs.len()]
                 } else {
                     all_ios_archs
@@ -112,7 +112,7 @@ impl PlatformSelector {
                 // defaults based on previous selections if previous selections are not empty
                 // otherwise, selects all
                 let all_android_archs = AndroidArch::all_strings();
-                let defaults: Vec<bool> = if !config.android.is_some() {
+                let defaults: Vec<bool> = if config.android.is_none() {
                     vec![true; all_android_archs.len()]
                 } else {
                     all_android_archs

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -32,7 +32,7 @@ impl PlatformSelector {
     /// `select` updates `platforms` in the config file.
     pub fn select(config: &mut Config) -> Self {
         let platforms = Platform::all_strings();
-        // defaults based on previous selections or all platforms
+        // defaults based on previous selections or none
         let defaults: Vec<bool> = if config.target_platforms.is_none() {
             vec![false; platforms.len()]
         } else {

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -80,24 +80,28 @@ impl PlatformSelector {
                 // defaults based on previous selections if previous selections are not empty
                 // otherwise, selects all
                 let all_ios_archs = IosArch::all_strings();
-                let defaults: Vec<bool> = if config.ios.is_empty() {
+                let defaults: Vec<bool> = if !config.ios.is_some() {
                     vec![true; all_ios_archs.len()]
                 } else {
                     all_ios_archs
                         .iter()
-                        .map(|&acrch| config.ios.contains(acrch))
+                        .map(|&acrch| config.ios.as_ref().unwrap().contains(acrch))
                         .collect()
                 };
 
                 // clear previous selections before update
-                config.ios.clear();
+                if let Some(ref mut ios) = config.ios {
+                    ios.clear();
+                }
 
                 let sel = Self::select_multi_archs(p.as_str(), &all_ios_archs, defaults);
                 let sel_str = sel
                     .iter()
                     .map(|&i| {
                         let arch = IosArch::from_idx(i).as_str().to_string();
-                        config.ios.insert(arch.clone());
+                        if let Some(ref mut ios) = config.ios {
+                            ios.insert(arch.clone());
+                        }
                         arch
                     })
                     .collect::<Vec<String>>();
@@ -108,24 +112,28 @@ impl PlatformSelector {
                 // defaults based on previous selections if previous selections are not empty
                 // otherwise, selects all
                 let all_android_archs = AndroidArch::all_strings();
-                let defaults: Vec<bool> = if config.android.is_empty() {
+                let defaults: Vec<bool> = if !config.android.is_some() {
                     vec![true; all_android_archs.len()]
                 } else {
                     all_android_archs
                         .iter()
-                        .map(|&acrch| config.android.contains(acrch))
+                        .map(|&acrch| config.android.as_ref().unwrap().contains(acrch))
                         .collect()
                 };
 
                 // clear previous selections before update
-                config.android.clear();
+                if let Some(ref mut android) = config.android {
+                    android.clear();
+                }
 
                 let sel = Self::select_multi_archs(p.as_str(), &all_android_archs, defaults);
                 let sel_str = sel
                     .iter()
                     .map(|&i| {
                         let arch = AndroidArch::from_idx(i).as_str().to_string();
-                        config.android.insert(arch.clone());
+                        if let Some(ref mut android) = config.android {
+                            android.insert(arch.clone());
+                        }
                         arch
                     })
                     .collect::<Vec<String>>();

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::{
     config::Config,
@@ -77,11 +77,10 @@ impl PlatformSelector {
         let mut archs: HashMap<String, Vec<String>> = HashMap::new();
         self.platforms.iter().for_each(|&p| match p {
             Platform::Ios => {
-                // defaults based on previous selections if previous selections are not empty
-                // otherwise, selects all
+                // defaults based on previous selections
                 let all_ios_archs = IosArch::all_strings();
                 let defaults: Vec<bool> = if config.ios.is_none() {
-                    vec![true; all_ios_archs.len()]
+                    vec![false; all_ios_archs.len()]
                 } else {
                     all_ios_archs
                         .iter()
@@ -90,9 +89,7 @@ impl PlatformSelector {
                 };
 
                 // clear previous selections before update
-                if let Some(ref mut ios) = config.ios {
-                    ios.clear();
-                }
+                config.ios = Some(HashSet::new());
 
                 let sel = Self::select_multi_archs(p.as_str(), &all_ios_archs, defaults);
                 let sel_str = sel
@@ -109,11 +106,10 @@ impl PlatformSelector {
                 self.archs.extend_from_slice(&sel_str);
             }
             Platform::Android => {
-                // defaults based on previous selections if previous selections are not empty
-                // otherwise, selects all
+                // defaults based on previous selections
                 let all_android_archs = AndroidArch::all_strings();
                 let defaults: Vec<bool> = if config.android.is_none() {
-                    vec![true; all_android_archs.len()]
+                    vec![false; all_android_archs.len()]
                 } else {
                     all_android_archs
                         .iter()
@@ -122,9 +118,7 @@ impl PlatformSelector {
                 };
 
                 // clear previous selections before update
-                if let Some(ref mut android) = config.android {
-                    android.clear();
-                }
+                config.android = Some(HashSet::new());
 
                 let sel = Self::select_multi_archs(p.as_str(), &all_android_archs, defaults);
                 let sel_str = sel
@@ -145,21 +139,17 @@ impl PlatformSelector {
         archs
     }
 
-    fn select_multi_archs(platform: &str, archs: &[&str], default: Vec<bool>) -> Vec<usize> {
+    fn select_multi_archs(platform: &str, archs: &[&str], defaults: Vec<bool>) -> Vec<usize> {
         // At least one architecture must be selected
         multi_select(
-            format!(
-                "Select {} architecture(s) to compile (default: all)",
-                platform
-            )
-            .as_str(),
+            format!("Select {} architecture(s) to compile", platform).as_str(),
             format!(
                 "No architectures selected for {}. Please select at least one architecture.",
                 platform
             )
             .as_str(),
             archs.to_vec(),
-            default,
+            defaults,
         )
     }
 


### PR DESCRIPTION
…tring>> for better handling of empty states
fix #415 

If there is no `ios` or `android` in `Config.toml`, then select all targets
If new targets are selected, then update the `Config.toml`