### PR TITLE
fix/unpredictable testing failure

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -256,7 +256,7 @@ jobs:
           key: ${{ github.sha }}-xcframework
       # to list available simulators: xcrun simctl list devices
       - name: Test app in simulator
-        run: xcodebuild -project ./test-e2e/ios/mopro-test.xcodeproj -scheme mopro-test -destination 'platform=iOS Simulator,name=iPhone 15' test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+        run: xcodebuild -project ./test-e2e/ios/mopro-test.xcodeproj -scheme mopro-test -destination 'platform=iOS Simulator,name=iPhone 15' test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -maximum-parallel-testing-workers 1
   build-android-lib:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
@@ -280,7 +280,7 @@ jobs:
         with:
           path: test-e2e/MoproAndroidBindings
           key: ${{ github.sha }}-android-lib
-  build-android-app:
+  test-android-app:
     runs-on: ubuntu-latest
     needs: build-android-lib
     steps:
@@ -310,13 +310,21 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - name: run tests
+      - name: Run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
           target: google_apis
           arch: x86_64
+          disable-animations: true
+          emulator-options: "-no-snapshot -no-boot-anim -no-window -gpu swiftshader_indirect -memory 2048 -cores 1"
           script: cd test-e2e/android && ./gradlew connectedAndroidTest
+      - name: Upload test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-test-report
+          path: test-e2e/android/app/build/reports/androidTests/connected/debug/
   build-halo2-wasm-web:
     runs-on: ubuntu-latest
     needs: setup-halo2-wasm-env

--- a/mopro-ffi/src/circom/mod.rs
+++ b/mopro-ffi/src/circom/mod.rs
@@ -123,7 +123,7 @@ pub fn generate_circom_proof_wtns(
     json_input_str: String,
     witness_fn: WitnessFn,
 ) -> Result<CircomProofResult> {
-    let ret = CircomProver::prove(proof_lib, witness_fn, json_input_str, zkey_path).unwrap();
+    let ret = CircomProver::prove(proof_lib, witness_fn, json_input_str, zkey_path)?;
     let (proof, public_inputs) = match ret.proof.curve.as_ref() {
         CURVE_BN254 => (ret.proof.into(), ret.pub_inputs.into()),
         CURVE_BLS12_381 => (ret.proof.into(), ret.pub_inputs.into()),

--- a/test-e2e/android/app/src/androidTest/java/com/mopro/mopro_app/ExampleInstrumentedTest.kt
+++ b/test-e2e/android/app/src/androidTest/java/com/mopro/mopro_app/ExampleInstrumentedTest.kt
@@ -2,6 +2,7 @@ package com.mopro.mopro_app
 
 import MultiplierComponent
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -42,11 +43,15 @@ class ExampleInstrumentedTest {
         composeTestRule.onNodeWithTag("circomGenerateProofButton").performClick()
         composeTestRule.onNodeWithTag("circomGenerateProofButton").assertIsDisplayed()
 
-        // Test click circom verify proof button
-        // Wait until the second button is enabled
-        Thread.sleep(500)
-
-        composeTestRule.onNodeWithTag("circomVerifyProofButton").performClick()
+        // Wait up to 5 seconds for any circomVerifyProofButton to become enabled before continuing the test
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            try {
+                composeTestRule.onNodeWithTag("circomVerifyProofButton").assertIsEnabled()
+                true
+            } catch (e: Exception) {
+                false
+            }
+        }
         composeTestRule.onNodeWithTag("circomVerifyProofButton").assertIsDisplayed()
     }
 
@@ -61,11 +66,16 @@ class ExampleInstrumentedTest {
         composeTestRule.onNodeWithTag("halo2GenerateProofButton").performClick()
         composeTestRule.onNodeWithTag("halo2GenerateProofButton").assertIsDisplayed()
 
-        // Test click circom verify proof button
-        // Wait until the second button is enabled
-        Thread.sleep(500)
+        // Wait up to 5 seconds for any halo2VerifyProofButton to become enabled before continuing the test
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            try {
+                composeTestRule.onNodeWithTag("halo2VerifyProofButton").assertIsEnabled()
+                true
+            } catch (e: Exception) {
+                false
+            }
+        }
 
-        composeTestRule.onNodeWithTag("halo2VerifyProofButton").performClick()
         composeTestRule.onNodeWithTag("halo2VerifyProofButton").assertIsDisplayed()
     }
 }

--- a/test-e2e/android/app/src/androidTest/java/com/mopro/mopro_app/ExampleInstrumentedTest.kt
+++ b/test-e2e/android/app/src/androidTest/java/com/mopro/mopro_app/ExampleInstrumentedTest.kt
@@ -44,7 +44,7 @@ class ExampleInstrumentedTest {
 
         // Test click circom verify proof button
         // Wait until the second button is enabled
-        Thread.sleep(500)
+        Thread.sleep(2000)
 
         composeTestRule.onNodeWithTag("circomVerifyProofButton").performClick()
         composeTestRule.onNodeWithTag("circomVerifyProofButton").assertIsDisplayed()
@@ -63,7 +63,7 @@ class ExampleInstrumentedTest {
 
         // Test click circom verify proof button
         // Wait until the second button is enabled
-        Thread.sleep(500)
+        Thread.sleep(2000)
 
         composeTestRule.onNodeWithTag("halo2VerifyProofButton").performClick()
         composeTestRule.onNodeWithTag("halo2VerifyProofButton").assertIsDisplayed()

--- a/test-e2e/android/app/src/androidTest/java/com/mopro/mopro_app/ExampleInstrumentedTest.kt
+++ b/test-e2e/android/app/src/androidTest/java/com/mopro/mopro_app/ExampleInstrumentedTest.kt
@@ -2,7 +2,6 @@ package com.mopro.mopro_app
 
 import MultiplierComponent
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -43,15 +42,11 @@ class ExampleInstrumentedTest {
         composeTestRule.onNodeWithTag("circomGenerateProofButton").performClick()
         composeTestRule.onNodeWithTag("circomGenerateProofButton").assertIsDisplayed()
 
-        // Wait up to 5 seconds for any circomVerifyProofButton to become enabled before continuing the test
-        composeTestRule.waitUntil(timeoutMillis = 5000) {
-            try {
-                composeTestRule.onNodeWithTag("circomVerifyProofButton").assertIsEnabled()
-                true
-            } catch (e: Exception) {
-                false
-            }
-        }
+        // Test click circom verify proof button
+        // Wait until the second button is enabled
+        Thread.sleep(500)
+
+        composeTestRule.onNodeWithTag("circomVerifyProofButton").performClick()
         composeTestRule.onNodeWithTag("circomVerifyProofButton").assertIsDisplayed()
     }
 
@@ -66,16 +61,11 @@ class ExampleInstrumentedTest {
         composeTestRule.onNodeWithTag("halo2GenerateProofButton").performClick()
         composeTestRule.onNodeWithTag("halo2GenerateProofButton").assertIsDisplayed()
 
-        // Wait up to 5 seconds for any halo2VerifyProofButton to become enabled before continuing the test
-        composeTestRule.waitUntil(timeoutMillis = 5000) {
-            try {
-                composeTestRule.onNodeWithTag("halo2VerifyProofButton").assertIsEnabled()
-                true
-            } catch (e: Exception) {
-                false
-            }
-        }
+        // Test click circom verify proof button
+        // Wait until the second button is enabled
+        Thread.sleep(500)
 
+        composeTestRule.onNodeWithTag("halo2VerifyProofButton").performClick()
         composeTestRule.onNodeWithTag("halo2VerifyProofButton").assertIsDisplayed()
     }
 }

--- a/test-e2e/ios/mopro-test-UITests/mopro_test_UITests.swift
+++ b/test-e2e/ios/mopro-test-UITests/mopro_test_UITests.swift
@@ -28,17 +28,12 @@ final class mopro_test_UITests: XCTestCase {
         app.launch()
         
         app.buttons["proveCircom"].tap()
-        var predicate = NSPredicate(format: "label CONTAINS[c] %@", "1️⃣")
-        var elementQuery = app.staticTexts.containing(predicate)
-        XCTAssert(elementQuery.count == 1)
-
-        // Wait for 2 seconds (or any suitable delay).
-        Thread.sleep(forTimeInterval: 2.0)
+        let proveText = app.staticTexts.containing(NSPredicate(format: "label CONTAINS[c] %@", "1️⃣")).firstMatch
+        XCTAssertTrue(proveText.waitForExistence(timeout: 5), "The time of proof generation is over 5 secs")
         
         app.buttons["verifyCircom"].tap()
-        predicate = NSPredicate(format: "label CONTAINS[c] %@", "2️⃣")
-        elementQuery = app.staticTexts.containing(predicate)
-        XCTAssert(elementQuery.count == 1)
+        let verifyText = app.staticTexts.containing(NSPredicate(format: "label CONTAINS[c] %@", "2️⃣")).firstMatch
+        XCTAssertTrue(verifyText.waitForExistence(timeout: 5), "The time of proof verification is over 5 secs")
     }
     
     func testHalo2ProveVerify() throws {
@@ -47,12 +42,11 @@ final class mopro_test_UITests: XCTestCase {
         app.launch()
         
         app.buttons["proveHalo2"].tap()
-        var predicate = NSPredicate(format: "label CONTAINS[c] %@", "1️⃣")
-        var elementQuery = app.staticTexts.containing(predicate)
-        XCTAssert(elementQuery.count == 1)
+        let proveText = app.staticTexts.containing(NSPredicate(format: "label CONTAINS[c] %@", "1️⃣")).firstMatch
+        XCTAssertTrue(proveText.waitForExistence(timeout: 5), "The time of proof generation is over 5 secs")
+        
         app.buttons["verifyHalo2"].tap()
-        predicate = NSPredicate(format: "label CONTAINS[c] %@", "2️⃣")
-        elementQuery = app.staticTexts.containing(predicate)
-        XCTAssert(elementQuery.count == 1)
+        let verifyText = app.staticTexts.containing(NSPredicate(format: "label CONTAINS[c] %@", "2️⃣")).firstMatch
+        XCTAssertTrue(verifyText.waitForExistence(timeout: 5), "The time of proof verification is over 5 secs")
     }
 }


### PR DESCRIPTION
## Reason
Trying to address the unstable CI tests on the iOS emulators.

## Details
Using the `sleep` function to wait a fixed period of time is not reliable in the test, especially in CI, due to limited resources. This PR removed the `sleep` function in the e2e-test for the ios platforms and used "wait.. until` mechanism.