### PR TITLE
fix: drop temporary Clippy lint override in `test-e2e/Cargo.toml`

### DIFF
--- a/test-e2e/Cargo.toml
+++ b/test-e2e/Cargo.toml
@@ -46,9 +46,5 @@ uniffi = { workspace = true, features = ["build"] }
 rust-witness = "0.1"
 witnesscalc-adapter = "0.1"
 
-# remove after uniffi is upgraded (see https://github.com/mozilla/uniffi-rs/issues/2346)
-[lints.clippy]
-empty-line-after-doc-comments = "allow"
-
 [dev-dependencies]
 uniffi = { workspace = true, features = ["bindgen-tests"] }


### PR DESCRIPTION
The override was a workaround for [mozilla/uniffi-rs#2346](https://github.com/mozilla/uniffi-rs/issues/2346).
That issue was fixed in uniffi 0.29.0, so the extra lint suppression is no longer required.