### PR TITLE
feat: add optional `uniffi` re-export via `mopro_ffi`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5150,7 +5150,6 @@ dependencies = [
  "plonk-fibonacci",
  "rust-witness",
  "thiserror 2.0.12",
- "uniffi",
  "witnesscalc-adapter",
 ]
 
@@ -5579,7 +5578,6 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "uniffi_bindgen",
- "uniffi_build",
  "uniffi_core",
  "uniffi_macros",
 ]
@@ -5606,17 +5604,6 @@ dependencies = [
  "uniffi_meta",
  "uniffi_testing",
  "uniffi_udl",
-]
-
-[[package]]
-name = "uniffi_build"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c887a6c9a2857d8dc2ab0c8d578e8aa4978145b4fd65ed44296341e89aebc3cc"
-dependencies = [
- "anyhow",
- "camino",
- "uniffi_bindgen",
 ]
 
 [[package]]

--- a/cli/src/create/write_toml.rs
+++ b/cli/src/create/write_toml.rs
@@ -45,7 +45,6 @@ default = ["<FEATURES>"]
 mopro-wasm = { git = "https://github.com/zkmopro/mopro.git" }
 mopro-ffi = { git = "https://github.com/zkmopro/mopro.git" }
 rust-witness = "0.1"
-uniffi = { version = "=0.29.0" }
 num-bigint = "0.4.0"
 thiserror = "2.0.12"
 # HALO2_DEPENDENCIES
@@ -53,9 +52,7 @@ thiserror = "2.0.12"
 # NOIR_DEPENDENCIES
 
 [build-dependencies]
-mopro-ffi = { git = "https://github.com/zkmopro/mopro.git" }
 rust-witness = "0.1"
-uniffi = { version = "=0.29.0", features = ["build"] }
 
 # CIRCOM_DEPENDENCIES
     "#

--- a/cli/src/create/write_toml.rs
+++ b/cli/src/create/write_toml.rs
@@ -43,7 +43,7 @@ default = ["<FEATURES>"]
 
 [dependencies]
 mopro-wasm = { git = "https://github.com/zkmopro/mopro.git" }
-mopro-ffi = { git = "https://github.com/zkmopro/mopro.git" }
+mopro-ffi = { git = "https://github.com/zkmopro/mopro.git", features = ["uniffi"] }
 rust-witness = "0.1"
 num-bigint = "0.4.0"
 thiserror = "2.0.12"

--- a/mopro-ffi/Cargo.toml
+++ b/mopro-ffi/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["target/*"]
 name = "mopro_ffi"
 
 [features]
-default = ["uniffi"]
+default = []
 
 uniffi = []
 uniffi-tests = ["uniffi", "uniffi/bindgen-tests"]

--- a/mopro-ffi/Cargo.toml
+++ b/mopro-ffi/Cargo.toml
@@ -13,7 +13,9 @@ exclude = ["target/*"]
 name = "mopro_ffi"
 
 [features]
-default = []
+default = ["uniffi"]
+
+uniffi = []
 
 halo2 = []
 circom = ["rustwitness", "arkworks"]
@@ -31,7 +33,7 @@ rapidsnark = ["circom-prover/rapidsnark"]
 circom-all = ["rustwitness", "witnesscalc", "arkworks", "rapidsnark"]
 
 [dependencies]
-uniffi = { workspace = true, features = ["build", "bindgen"] }
+uniffi = { workspace = true, features = ["bindgen"] }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0.86"
 num-bigint = { version = "0.4.3", default-features = false, features = [
@@ -61,7 +63,6 @@ serde_json = "1.0.94"
 
 [build-dependencies]
 rust-witness = { version = "0.1", optional = true }
-uniffi = { workspace = true, features = ["build"] }
 witnesscalc-adapter = { version = "0.1", optional = true }
 
 [dev-dependencies]

--- a/mopro-ffi/Cargo.toml
+++ b/mopro-ffi/Cargo.toml
@@ -31,7 +31,7 @@ rapidsnark = ["circom-prover/rapidsnark"]
 circom-all = ["rustwitness", "witnesscalc", "arkworks", "rapidsnark"]
 
 [dependencies]
-uniffi = { workspace = true, features = ["build", "cargo-metadata", "bindgen"] }
+uniffi = { workspace = true, features = ["build", "bindgen"] }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0.86"
 num-bigint = { version = "0.4.3", default-features = false, features = [

--- a/mopro-ffi/Cargo.toml
+++ b/mopro-ffi/Cargo.toml
@@ -16,6 +16,7 @@ name = "mopro_ffi"
 default = ["uniffi"]
 
 uniffi = []
+uniffi-tests = ["uniffi", "uniffi/bindgen-tests"]
 
 halo2 = []
 circom = ["rustwitness", "arkworks"]

--- a/mopro-ffi/src/lib.rs
+++ b/mopro-ffi/src/lib.rs
@@ -4,10 +4,10 @@ pub mod app_config;
 // UniFFI re-export
 //
 // Uniffi macros use fully qualified paths (`::uniffi::*`) internally.
-// To allow downstream crates to transparently resolve these macros to `mopro_ffi`, 
+// To allow downstream crates to transparently resolve these macros to `mopro_ffi`,
 // users must alias it (`extern crate mopro_ffi as uniffi;`, automated via `app!` macro).
 //
-// However, for this alias to work correctly, `mopro_ffi` must provide the exact same 
+// However, for this alias to work correctly, `mopro_ffi` must provide the exact same
 // exported items as the original `uniffi`. Hence, we re-export all individual items.
 #[cfg(feature = "uniffi")]
 pub use uniffi::*;
@@ -231,7 +231,6 @@ pub struct Halo2ProofResult {
 macro_rules! app {
     () => {
         mopro_ffi::uniffi_setup!();
-
 
         uniffi::setup_scaffolding!("mopro");
 

--- a/mopro-ffi/src/lib.rs
+++ b/mopro-ffi/src/lib.rs
@@ -14,7 +14,7 @@ pub use uniffi::*;
 
 #[cfg(feature = "uniffi")]
 #[macro_export]
-macro_rules! uniffi_reexport_scaffolding {
+macro_rules! uniffi_setup {
     () => {
         // `::uniffi` must be available in the caller’s extern-prelude.
         extern crate mopro_ffi as uniffi;
@@ -23,7 +23,7 @@ macro_rules! uniffi_reexport_scaffolding {
 
 #[cfg(not(feature = "uniffi"))]
 #[macro_export]
-macro_rules! uniffi_reexport_scaffolding {
+macro_rules! uniffi_setup {
     () => {
         // No-op when `uniffi` feature isn't enabled in `mopro_ffi`.
     };
@@ -230,8 +230,7 @@ pub struct Halo2ProofResult {
 #[macro_export]
 macro_rules! app {
     () => {
-        
-        mopro_ffi::uniffi_reexport_scaffolding!();
+        mopro_ffi::uniffi_setup!();
 
 
         uniffi::setup_scaffolding!("mopro");

--- a/test-e2e/Cargo.toml
+++ b/test-e2e/Cargo.toml
@@ -25,7 +25,6 @@ mopro-ffi = { path = "../mopro-ffi", features = [
     "rapidsnark",
 ] }
 mopro-wasm = { path = "../mopro-wasm" }
-uniffi = { workspace = true }
 
 # Circom dependencies
 rust-witness = "0.1"
@@ -40,7 +39,6 @@ thiserror = "2.0.12"
 
 [build-dependencies]
 mopro-ffi = { path = "../mopro-ffi" }
-uniffi = { workspace = true, features = ["build"] }
 
 # Circom dependencies
 rust-witness = "0.1"

--- a/test-e2e/Cargo.toml
+++ b/test-e2e/Cargo.toml
@@ -18,6 +18,7 @@ name = "web"
 
 [dependencies]
 mopro-ffi = { path = "../mopro-ffi", features = [
+    "uniffi",
     "halo2",
     "circom",
     "noir",

--- a/test-e2e/Cargo.toml
+++ b/test-e2e/Cargo.toml
@@ -49,4 +49,4 @@ witnesscalc-adapter = "0.1"
 empty-line-after-doc-comments = "allow"
 
 [dev-dependencies]
-uniffi = { workspace = true, features = ["bindgen-tests"] }
+mopro-ffi = { path = "../mopro-ffi", features = ["uniffi-tests"] }

--- a/test-e2e/tests/circom.rs
+++ b/test-e2e/tests/circom.rs
@@ -1,4 +1,4 @@
-uniffi::build_foreign_language_testcases!(
+mopro_ffi::build_foreign_language_testcases!(
     "tests/bindings/test_circom_multiplier2.swift",
     "tests/bindings/test_circom_multiplier2.kts",
     "tests/bindings/test_circom_keccak.swift",

--- a/test-e2e/tests/circom.rs
+++ b/test-e2e/tests/circom.rs
@@ -1,4 +1,6 @@
-mopro_ffi::build_foreign_language_testcases!(
+mopro_ffi::uniffi_setup!();
+
+uniffi::build_foreign_language_testcases!(
     "tests/bindings/test_circom_multiplier2.swift",
     "tests/bindings/test_circom_multiplier2.kts",
     "tests/bindings/test_circom_keccak.swift",

--- a/test-e2e/tests/halo2.rs
+++ b/test-e2e/tests/halo2.rs
@@ -1,4 +1,4 @@
-uniffi::build_foreign_language_testcases!(
+mopro_ffi::build_foreign_language_testcases!(
     "tests/bindings/test_plonk_fibonacci.swift",
     "tests/bindings/test_plonk_fibonacci.kts",
     "tests/bindings/test_halo2_keccak256.swift",

--- a/test-e2e/tests/halo2.rs
+++ b/test-e2e/tests/halo2.rs
@@ -1,4 +1,6 @@
-mopro_ffi::build_foreign_language_testcases!(
+mopro_ffi::uniffi_setup!();
+
+uniffi::build_foreign_language_testcases!(
     "tests/bindings/test_plonk_fibonacci.swift",
     "tests/bindings/test_plonk_fibonacci.kts",
     "tests/bindings/test_halo2_keccak256.swift",


### PR DESCRIPTION
Closes #356.

# Problem  
Downstream crates had to depend on both `mopro_ffi` and `uniffi` in `Cargo.toml`.  
This duplicated dependencies, risked version mismatches, and cluttered project manifests.

# What changed  

1. **UniFFI re-export**  
   The new `uniffi` feature (not enabled by default) re-exports all UniFFI crates items:


```rust
   #[cfg(feature = "uniffi")]
   pub use uniffi::*;
```


2. **Crate-alias macro**  
    UniFFI’s macros reference `::uniffi::*` directly.     To satisfy them, we introduce `uniffi_setup!()`, which shadows the crate name:

```rust
   #[cfg(feature = "uniffi")]
   #[macro_export]
   macro_rules! uniffi_setup {
       () => {
           extern crate mopro_ffi as uniffi;
       };
   }
```

   The `app!` macro now expands this automatically; downstream code needs no changes.


3. **Testing support**  
   Added a companion feature `uniffi-test` that re-exports UniFFI’s test helpers.

# Benefits  
- **Simpler manifests** - only `mopro_ffi` is required.  
- **Version safety** - UniFFI’s version is locked to the one shipped with Mopro.  
- **Cleaner code** - UniFFI macros resolve transparently through the alias.  
- **Backwards compatible** - the feature is opt-in and does not affect existing setups.

# Next steps  
- Look for a cleaner way to re-export the the UniFFI without overshadowing `uniffi` with `mopro_ffi`.
- Consider whether to enable the `uniffi` feature by default, with a compatibility break.