### PR TITLE
Fix broken link to Architectures section in getting-started guide

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -116,7 +116,7 @@ $ mopro build
 :::
 
 :::info
-See more details about the architectures in [Architectures](architectures) Section
+See more details about the architectures in [Architectures](./architectures.md) Section
 :::
 
 :::warning


### PR DESCRIPTION
This commit updates the link to the Architectures section in docs/docs/getting-started.md to point to the correct file (./architectures.md). The previous link was broken due to a missing or incorrect file path. This change ensures that users can access the relevant documentation without encountering a 404 error.