### PR TITLE
fix: update broken wasm-bindgen documentation link

### DIFF
--- a/cli/src/template/mopro-wasm-lib/src/lib.rs
+++ b/cli/src/template/mopro-wasm-lib/src/lib.rs
@@ -5,7 +5,7 @@ use mopro_wasm::halo2::{gemini, hyperplonk, plonk};
 use wasm_bindgen::prelude::wasm_bindgen;
 
 // Customize your code here
-// Reference: https://rustwasm.github.io/wasm-bindgen/reference/types.html
+// Reference: https://rustwasm.github.io/docs/wasm-bindgen/reference/types.html
 //
 #[wasm_bindgen(js_name = "moproWasmHelloWorld")]
 pub fn mopro_wasm_hello_world() -> String {


### PR DESCRIPTION
Update the wasm-bindgen documentation URL from the old broken link
to the correct current documentation URL.

- Changed from: https://rustwasm.github.io/wasm-bindgen/reference/types.html
- Changed to: https://rustwasm.github.io/docs/wasm-bindgen/reference/types.html

This fixes the broken reference link in the template library file.