### PR TITLE
Fix broken GitHub issue link in ETHTaipei workshop blog post

### DIFF
--- a/docs/blog/2025-03-27-ethtaipei-workshop.md
+++ b/docs/blog/2025-03-27-ethtaipei-workshop.md
@@ -274,7 +274,7 @@ This section explains how to update circuits with alternative witness generators
 
     :::info
     We aim to provide the `mopro update` CLI tool to assist with updating bindings.
-    Contributions to this effort are welcome.https://github.com/zkmopro/mopro/issues/269
+    Contributions to this effort are welcome. [GitHub Issue #269](https://github.com/zkmopro/mopro/issues/269)
     :::
 
 5.  Copy zkeys to assets


### PR DESCRIPTION

Fixes a broken link in the ETHTaipei workshop blog post where a GitHub issue URL was not properly formatted as a Markdown link.

## Changes
- **File:** `docs/blog/2025-03-27-ethtaipei-workshop.md`
- **Line 277:** Converted raw URL to proper Markdown link format
- **Before:** `Contributions to this effort are welcome.https://github.com/zkmopro/mopro/issues/269`
- **After:** `Contributions to this effort are welcome. [GitHub Issue #269](https://github.com/zkmopro/mopro/issues/269)`

