### PR TITLE
Feat cli bindgen

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,9 @@ name = "mopro"
 path = "src/main.rs"
 
 [dependencies]
-mopro-ffi = { path = "../mopro-ffi", features = ["build"], default-features = false }
+mopro-ffi = { path = "../mopro-ffi", features = [
+    "build",
+], default-features = false }
 
 clap = { version = "4.0", features = ["derive"] }
 fs_extra = "1.2.0"

--- a/cli/README.md
+++ b/cli/README.md
@@ -54,6 +54,12 @@ mopro create
 mopro update
 ```
 
+### Create bindings without Rust project
+
+```sh
+mopro bindgen
+```
+
 ## Development
 
 After cloning the repository, you can install the CLI locally with your changes by running:

--- a/cli/src/bindgen.rs
+++ b/cli/src/bindgen.rs
@@ -1,0 +1,134 @@
+use std::{env, ffi::OsStr, fs, path::Path};
+
+use anyhow::Result;
+use dialoguer::{theme::ColorfulTheme, Input};
+use mopro_ffi::app_config::constants::{ANDROID_BINDINGS_DIR, IOS_BINDINGS_DIR};
+use walkdir::WalkDir;
+
+use crate::{
+    build::build_project,
+    init::{adapter::Adapter, init_project},
+};
+
+pub fn bindgen(
+    arg_mode: &Option<String>,
+    arg_platforms: &Option<Vec<String>>,
+    arg_architectures: &Option<Vec<String>>,
+    circuit_dir: &Option<String>,
+) -> Result<()> {
+    // Currently only support circom
+    let adapter = Adapter::Circom;
+
+    // Find the circuit name
+
+    let mut specified_circuit_dir = String::new();
+    if let Some(circuit_dir) = circuit_dir {
+        specified_circuit_dir = circuit_dir.to_string();
+    } else {
+        specified_circuit_dir = Input::with_theme(&ColorfulTheme::default())
+            .with_prompt("Circuit folder path")
+            .with_initial_text("./circuit".to_string())
+            .interact_text()?;
+    }
+
+    // Convert relative path to absolute path
+    let current_dir = env::current_dir()?;
+    let absolute_circuit_dir = if Path::new(&specified_circuit_dir).is_absolute() {
+        Path::new(&specified_circuit_dir).to_path_buf()
+    } else {
+        current_dir.join(&specified_circuit_dir)
+    };
+
+    // Verify the directory exists
+    if !absolute_circuit_dir.exists() {
+        return Err(anyhow::anyhow!(
+            "Circuit directory does not exist: {:?}",
+            absolute_circuit_dir
+        ));
+    }
+
+    if !absolute_circuit_dir.is_dir() {
+        return Err(anyhow::anyhow!(
+            "Circuit path is not a directory: {:?}",
+            absolute_circuit_dir
+        ));
+    }
+
+    let mut project_name = String::new();
+
+    for entry in WalkDir::new(&absolute_circuit_dir) {
+        let e = entry.unwrap();
+        let path = e.path();
+        if path.is_dir() {
+            continue;
+        }
+        let ext = path.extension().and_then(OsStr::to_str).unwrap_or("");
+        // Iterate over all wasm files and generate c source, then compile each source to
+        // a static library that can be called from rust
+        if ext != "wasm" {
+            continue;
+        }
+        // make source files with the same name as the wasm binary file
+        let circuit_name = path.file_stem().unwrap();
+        let circuit_name_compressed = circuit_name
+            .to_str()
+            .unwrap()
+            .replace("_", "")
+            .replace("-", "");
+        project_name = circuit_name_compressed;
+        // TODO: find zkey and wasm mapping
+    }
+
+    init_project(
+        &Some(adapter.as_str().to_string()),
+        &Some(project_name.to_string()),
+    )?;
+
+    let project_dir = env::current_dir()?;
+    let test_vectors_dir = project_dir.join("test-vectors").join("circom");
+    fs::create_dir_all(&test_vectors_dir)?;
+
+    // Copy the entire directory recursively
+    // Remove the destination directory if it exists to avoid conflicts
+    if test_vectors_dir.exists() {
+        fs::remove_dir_all(&test_vectors_dir)?;
+    }
+    // Copy the entire directory
+    fs_extra::dir::copy(
+        &absolute_circuit_dir,
+        test_vectors_dir.parent().unwrap(),
+        &fs_extra::dir::CopyOptions::new(),
+    )?;
+
+    // TODO: Update rust_witness functions
+
+    // Run the build command
+    build_project(arg_mode, arg_platforms, arg_architectures)?;
+
+    // Copy the bindings folder to the project root
+    let ios_bindings_dir = project_dir.join(IOS_BINDINGS_DIR);
+    if ios_bindings_dir.exists() {
+        let output_ios_bindings_dir = current_dir.join(IOS_BINDINGS_DIR);
+        fs::create_dir_all(&output_ios_bindings_dir)?;
+        fs_extra::dir::copy(
+            &ios_bindings_dir,
+            &output_ios_bindings_dir,
+            &fs_extra::dir::CopyOptions::new(),
+        )?;
+    }
+
+    let android_bindings_dir = project_dir.join(ANDROID_BINDINGS_DIR);
+    if android_bindings_dir.exists() {
+        let output_android_bindings_dir = current_dir.join(ANDROID_BINDINGS_DIR);
+        fs::create_dir_all(&output_android_bindings_dir)?;
+        fs_extra::dir::copy(
+            &android_bindings_dir,
+            &output_android_bindings_dir,
+            &fs_extra::dir::CopyOptions::new(),
+        )?;
+    }
+
+    fs::remove_dir_all(&project_dir)?;
+
+    Ok(())
+}

--- a/cli/src/bindgen.rs
+++ b/cli/src/bindgen.rs
@@ -167,7 +167,7 @@ fn generate_rust_witness_functions(circuit_map: &HashMap<String, String>) -> Str
     let mut content = String::new();
     for key in circuit_map.keys() {
         let rust_witness_key = key.replace("_", "").replace("-", "");
-        content.push_str(&format!("rust_witness::witness!({});\n", rust_witness_key));
+        content.push_str(&format!("rust_witness::witness!({rust_witness_key});\n"));
     }
 
     content.push('\n');
@@ -176,8 +176,7 @@ fn generate_rust_witness_functions(circuit_map: &HashMap<String, String>) -> Str
     for (key, value) in circuit_map {
         let rust_witness_key = key.replace("_", "").replace("-", "");
         content.push_str(&format!(
-            "({:?}, mopro_ffi::witness::WitnessFn::RustWitness({}_witness)),\n",
-            value, rust_witness_key
+            "({value:?}, mopro_ffi::witness::WitnessFn::RustWitness({rust_witness_key}_witness)),\n"
         ));
     }
 

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -193,7 +193,7 @@ fn replace_features(file_path: &str, adapters: Vec<&str>) -> Result<()> {
     replace_string_in_file(file_path, target, &features.join(", "))
 }
 
-fn replace_string_in_file(file_path: &str, target: &str, replacement: &str) -> Result<()> {
+pub fn replace_string_in_file(file_path: &str, target: &str, replacement: &str) -> Result<()> {
     // Read the entire content of the file
     let content = fs::read_to_string(file_path)?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,6 +5,7 @@ use clap::Subcommand;
 use crate::constants::Framework;
 use crate::create::{Android, Create, Flutter, Ios, ReactNative, Web};
 
+mod bindgen;
 mod build;
 mod config;
 mod constants;
@@ -62,6 +63,22 @@ enum Commands {
     },
     /// Update the bindings for all platforms
     Update {},
+    /// Generate the bindings for the specified platform (NOTE: it only supports circom with rust-witness and arkworks now)
+    Bindgen {
+        #[arg(long, help = "Specify the build mode (e.g., 'release' or 'debug').")]
+        mode: Option<String>,
+        #[arg(long, num_args = 1.., help = "Specify the platforms to build for (e.g., 'ios', 'android').")]
+        platforms: Option<Vec<String>>,
+        #[arg(long, num_args = 1.., help = "Specify the architectures to build for (e.g., 'aarch64-apple-ios', 'aarch64-apple-ios-sim', x86_64-apple-ios, x86_64-linux-android, i686-linux-android, armv7-linux-androideabi, aarch64-linux-android).")]
+        architectures: Option<Vec<String>>,
+        #[arg(
+            long,
+            help = "path to the circuit directory (it should contain `.wtns` and `.zkey` files)"
+        )]
+        circuit_dir: Option<String>,
+        #[arg(long, help = "Show instruction message for build")]
+        show: bool,
+    },
 }
 
 fn main() {
@@ -132,5 +149,22 @@ fn main() {
             Ok(_) => {}
             Err(e) => style::print_red_bold(format!("Failed to update bindings: {e:?}")),
         },
+
+        Commands::Bindgen {
+            mode,
+            platforms,
+            architectures,
+            circuit_dir,
+            show,
+        } => {
+            if *show {
+                // TODO: print bindgen instructions
+                return;
+            }
+            match bindgen::bindgen(mode, platforms, architectures, circuit_dir) {
+                Ok(_) => {}
+                Err(e) => style::print_red_bold(format!("Failed to generate bindings: {e:?}")),
+            }
+        }
     }
 }

--- a/docs/docs/setup/rust-setup.md
+++ b/docs/docs/setup/rust-setup.md
@@ -6,6 +6,10 @@ This tutorial guides you through building iOS and Android bindings from a Rust p
 -   [**🔐 Integrating a ZK prover**](#-integrating-a-zk-prover) – Add support for Circom, Halo2, and/or Noir.
 -   [**🦄 customize the bindings**](#-customize-the-bindings) using any Rust crate, making it easy to expose your logic to mobile platforms.
 
+If you want to quickly get started with Circom `.wasm` and `.zkey` files, refer to the
+
+-   [**📋 Generating Circom Bindings**](#-generate-circom-bindings) section.
+
 :::info
 Make sure you've installed the [prerequisites](/docs/prerequisites).
 :::
@@ -522,6 +526,52 @@ Similar to Circom-based Rust project setup [3. Generate bindings for iOS and And
 Once the bindings are generated, you'll see your exported functions (e.g., `semaphoreProve`, `semaphoreVerify`) included in the generated code—for example, in `MoproiOSBindings/mopro.swift` for iOS and `MoproAndroidBindings/uniffi/mopro/mopro.kt` for Android.
 
 You can then use these functions directly within your iOS and/or Android applications as part of the generated bindings.
+
+## 📋 Generate Circom bindings
+
+<!-- TODO: update mopro-cli package -->
+
+Install the latest CLI from GitHub:
+
+```sh
+git clone https://github.com/zkmopro/mopro
+cd mopro/cli
+cargo install --path .
+```
+
+Use `mopro bindgen` to specify your circuit path and target architectures (e.g., iOS or Android):
+
+-   Specify configuration directly in the CLI command
+
+```sh
+mopro bindgen
+```
+
+-   Specify circuit directory
+
+```sh
+mopro bindgen --circuit-dir ./test-vectors/circom
+```
+
+-   Specify circuit directory, build mode, and architectures
+
+```sh
+mopro bindgen \
+  --circuit-dir ./test-vectors/circom \
+  --mode release \
+  --platforms ios \
+  --architectures aarch64-apple-ios-sim
+```
+
+-   View all available options:
+
+```sh
+mopro bindgen --help
+```
+
+:::warning
+Currently, only the [`rust-witness`](https://github.com/chancehudson/rust-witness) witness generator is supported.
+:::
 
 ### 3. What's next
 


### PR DESCRIPTION
close #366 
- use `mopro bindgen` to generate bindings in the folder where executing the command
   - requires to input a circuit folder e.g. `test-vectors/circom`
   - it copies the keys to folder created by `mopro init` e.g. `project/test-vectors/circom`
   - replace the `src/lib.rs` to compile the rust-witness functions
   - run `mopro build` for selected architecture
   - output a `MoproiOSBindings` or `MoproAndroidBindings` in the root folder and delete the temp project

- TODOs in the future PR
   - support `witnesscalc_adapter`
   - add output path
   - remove helping messages (it prints all `mopro init`,  `mopro build` messages)