### PR TITLE
fix: parse call to use generic type instead of Arch

### DIFF
--- a/mopro-ffi/src/app_config/mod.rs
+++ b/mopro-ffi/src/app_config/mod.rs
@@ -155,7 +155,7 @@ fn get_target_archs<A: Arch>() -> Vec<A> {
             return vec![];
         }
 
-        archs_str.split(',').map(Arch::parse_from_str).collect()
+        archs_str.split(',').map(A::parse_from_str).collect()
     } else {
         // Default case: select all supported architectures if none are provided
         A::all_strings()


### PR DESCRIPTION
changed the code to call `parse_from_str` on `A` instead of `Arch` so it uses the right type.
this fixes the bug and keeps it generic.
