### PR TITLE
fix: update broken wasm-pack installer link in README

### DIFF
--- a/mopro-wasm/README.md
+++ b/mopro-wasm/README.md
@@ -13,7 +13,7 @@ from: [Rayon - github](https://github.com/rayon-rs/rayon#usage-with-webassembly)
 
 ## Getting started
 
-- Install [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/)
+- Install [wasm-pack](https://drager.github.io/wasm-pack/installer/)
 - Install `chrome` and `chromedriver` with the same version, Refer to [Download Chrome/ChromeDriver](https://googlechromelabs.github.io/chrome-for-testing/).
 
 ## Run tests


### PR DESCRIPTION
Replaced outdated wasm-pack installer URL with an updated link in mopro-wasm/README.md.

Broken: https://rustwasm.github.io/wasm-pack/installer/
Correct: https://drager.github.io/wasm-pack/installer/