### PR TITLE
refactor: remove unused SNARK import from arkworks.rs

### DIFF
--- a/circom-prover/src/prover/arkworks.rs
+++ b/circom-prover/src/prover/arkworks.rs
@@ -2,7 +2,6 @@ use anyhow::bail;
 use anyhow::Result;
 use ark_bls12_381::Bls12_381;
 use ark_bn254::Bn254;
-use ark_crypto_primitives::snark::SNARK;
 use ark_ec::pairing::Pairing;
 use ark_ff::{BigInteger, PrimeField};
 use ark_groth16::{prepare_verifying_key, Groth16, ProvingKey, VerifyingKey};


### PR DESCRIPTION
Remove unused import of ark_crypto_primitives::snark::SNARK from arkworks.rs

The SNARK trait was imported but never used in the code. The Groth16 
implementation uses static methods directly rather than trait methods, 
making this import unnecessary.
