### PR TITLE
added auto_update option to CLI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -39,7 +39,7 @@ mopro init
 ### Build bindings
 
 ```sh
-mopro build
+mopro build --auto-update
 ```
 
 ### Create templates

--- a/cli/src/bindgen.rs
+++ b/cli/src/bindgen.rs
@@ -133,7 +133,7 @@ pub fn bindgen(
     )?;
 
     // Run the build command
-    build_project(arg_mode, arg_platforms, arg_architectures)?;
+    build_project(arg_mode, arg_platforms, arg_architectures, false, false)?;
 
     // Copy the bindings folder to the project root
     let ios_bindings_dir = project_dir.join(IOS_BINDINGS_DIR);

--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -22,12 +22,15 @@ use crate::print::print_build_success_message;
 use crate::style;
 use crate::style::blue_bold;
 use crate::style::print_green_bold;
+use crate::update::update_bindings;
 use crate::utils::PlatformSelector;
 
 pub fn build_project(
     arg_mode: &Option<String>,
     arg_platforms: &Option<Vec<String>>,
     arg_architectures: &Option<Vec<String>>,
+    auto_update_flag: bool,
+    no_auto_update_flag: bool,
 ) -> Result<()> {
     // Detect `Cargo.toml` file before starting build process
     let current_dir = env::current_dir()?;
@@ -51,6 +54,7 @@ pub fn build_project(
             target_platforms: Some(HashSet::new()),
             ios: Some(HashSet::new()),
             android: Some(HashSet::new()),
+            auto_update: None,
         };
         write_config(&config_path, &default_config)?;
     }
@@ -119,6 +123,8 @@ pub fn build_project(
             &Some(mode.as_str().to_string()),
             arg_platforms,
             arg_architectures,
+            auto_update_flag,
+            no_auto_update_flag,
         )?;
         return Ok(());
     }
@@ -135,6 +141,8 @@ pub fn build_project(
                 &Some(mode.as_str().to_string()),
                 arg_platforms,
                 arg_architectures,
+                auto_update_flag,
+                no_auto_update_flag,
             )?;
             return Ok(());
         }
@@ -183,6 +191,8 @@ pub fn build_project(
                 &Some(mode.as_str().to_string()),
                 arg_platforms,
                 arg_architectures,
+                auto_update_flag,
+                no_auto_update_flag,
             )?;
             return Ok(());
         }
@@ -230,6 +240,13 @@ pub fn build_project(
     }
 
     print_binding_message(&platform.platforms)?;
+    handle_auto_update(
+        &config_path,
+        &mut config,
+        auto_update_flag,
+        no_auto_update_flag,
+    )?;
+    print_build_success_message();
 
     Ok(())
 }
@@ -264,7 +281,6 @@ fn print_binding_message(platforms: &Vec<Platform>) -> anyhow::Result<()> {
         let text = format!("- {}/{}", current_dir.display(), platform.binding_dir());
         println!("{}", blue_bold(text.to_string()));
     }
-    print_build_success_message();
     Ok(())
 }
 
@@ -276,6 +292,51 @@ fn copy_mopro_wasm_lib() -> anyhow::Result<()> {
         const WASM_TEMPLATE_DIR: Dir =
             include_dir!("$CARGO_MANIFEST_DIR/src/template/mopro-wasm-lib");
         copy_embedded_dir(&WASM_TEMPLATE_DIR, &target_dir)?;
+    }
+
+    Ok(())
+}
+
+fn handle_auto_update(
+    config_path: &std::path::Path,
+    config: &mut Config,
+    auto_update_flag: bool,
+    no_auto_update_flag: bool,
+) -> Result<()> {
+    if auto_update_flag {
+        update_bindings()?;
+        return Ok(());
+    }
+
+    if no_auto_update_flag {
+        return Ok(());
+    }
+
+    if let Some(auto) = config.auto_update {
+        if auto {
+            update_bindings()?;
+        }
+        return Ok(());
+    }
+
+    println!();
+    let run_now = Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Run `mopro update` now to copy them into your platform projects?")
+        .default(true)
+        .interact()?;
+
+    if run_now {
+        update_bindings()?;
+    }
+
+    let remember = Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Remember this choice for future builds?")
+        .default(false)
+        .interact()?;
+
+    if remember {
+        config.auto_update = Some(run_now);
+        write_config(&config_path.to_path_buf(), config)?;
     }
 
     Ok(())

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub(crate) target_platforms: Option<HashSet<String>>,
     pub(crate) ios: Option<HashSet<String>>,
     pub(crate) android: Option<HashSet<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) auto_update: Option<bool>,
 }
 
 impl Config {

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -88,6 +88,7 @@ pub fn init_project(
             target_platforms: Some(HashSet::new()),
             ios: Some(HashSet::new()),
             android: Some(HashSet::new()),
+            auto_update: None,
         };
         write_config(&config_path, &default_config)?;
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -47,6 +47,18 @@ enum Commands {
         platforms: Option<Vec<String>>,
         #[arg(long, num_args = 1.., help = "Specify the architectures to build for (e.g., 'aarch64-apple-ios', 'aarch64-apple-ios-sim', x86_64-apple-ios, x86_64-linux-android, i686-linux-android, armv7-linux-androideabi, aarch64-linux-android).")]
         architectures: Option<Vec<String>>,
+        #[arg(
+            long,
+            help = "Automatically run mopro update after build",
+            conflicts_with = "no_auto_update"
+        )]
+        auto_update: bool,
+        #[arg(
+            long,
+            help = "Skip running mopro update and disable the prompt",
+            conflicts_with = "auto_update"
+        )]
+        no_auto_update: bool,
         #[arg(long, help = "Show instruction message for build")]
         show: bool,
     },
@@ -103,13 +115,15 @@ fn main() {
             mode,
             platforms,
             architectures,
+            auto_update,
+            no_auto_update,
             show,
         } => {
             if *show {
                 print::print_build_success_message();
                 return;
             }
-            match build::build_project(mode, platforms, architectures) {
+            match build::build_project(mode, platforms, architectures, *auto_update, *no_auto_update) {
                 Ok(_) => {}
                 Err(e) => style::print_red_bold(format!("Failed to build project: {e:?}")),
             }

--- a/cli/src/template/init/README.md
+++ b/cli/src/template/init/README.md
@@ -80,8 +80,13 @@ Follow the README in the `flutter` directory. Or [zkmopro/flutter-app/README.md]
 
 After creating templates, you may still need to update the bindings.
 
-Once you've run `mopro build`, be sure to run mopro update to refresh the bindings in each template. This command will automatically locate the corresponding bindings folders and update them accordingly.
+`mopro build` will prompt you to run `mopro update` to refresh the bindings in each template. You can also run it automatically:
 
+```sh
+mopro build --auto-update
+```
+
+Or manually:
 ```sh
 mopro update
 ```


### PR DESCRIPTION
Fixes #483 

## Summary
- Added a persisted `auto_update` option to the CLI configuration, enabling users to remember whether `mopro update` runs automatically after builds
- Integrated automatic or interactive update behavior into the build process, invoking a prompt when no preference is set and honoring `--auto-update`/`--no-auto-update` flags
- Introduced new CLI flags in the build command to control automatic updates and updated documentation accordingly
