### PR TITLE
Added new options to mopro bindgen

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -72,6 +72,21 @@ android_dest = "../MyAndroidApp"
 mopro bindgen
 ```
 
+You can customize the bindings generation:
+
+- Choose a witness generator adapter (default `rust-witness`):
+
+  ```sh
+  mopro bindgen --adapter witnesscalc
+  ```
+
+- Specify the output directory for generated bindings:
+
+  ```sh
+  mopro bindgen --output-dir ./output
+  ```
+
+
 ## Development
 
 After cloning the repository, you can install the CLI locally with your changes by running:

--- a/cli/src/bindgen.rs
+++ b/cli/src/bindgen.rs
@@ -1,4 +1,5 @@
 use crate::init::replace_string_in_file;
+use crate::style;
 use std::{collections::HashMap, env, ffi::OsStr, fs, path::Path};
 
 use anyhow::Result;
@@ -13,14 +14,28 @@ use crate::{
     init::{adapter::Adapter, init_project},
 };
 
+#[derive(PartialEq)]
+enum WitnessAdapter {
+    RustWitness,
+    WitnessCalc,
+}
+
 pub fn bindgen(
     arg_mode: &Option<String>,
     arg_platforms: &Option<Vec<String>>,
     arg_architectures: &Option<Vec<String>>,
     circuit_dir: &Option<String>,
+    adapter: &Option<String>,
+    output_dir: &Option<String>,
 ) -> Result<()> {
-    // Currently only support circom
-    let adapter = Adapter::Circom;
+    let witness_adapter = match adapter.as_deref() {
+        Some("witnesscalc") => WitnessAdapter::WitnessCalc,
+        Some("rust-witness") | None => WitnessAdapter::RustWitness,
+        Some(other) => return Err(anyhow::anyhow!(format!("Unsupported adapter: {other}"))),
+    };
+
+    // Currently only support circom proving system
+    let proving_adapter = Adapter::Circom;
 
     let specified_circuit_dir;
     if let Some(circuit_dir) = circuit_dir {
@@ -34,6 +49,16 @@ pub fn bindgen(
 
     // Convert relative path to absolute path
     let current_dir = env::current_dir()?;
+    let output_base_dir = if let Some(out) = output_dir {
+        let path = Path::new(out);
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            current_dir.join(path)
+        }
+    } else {
+        current_dir.clone()
+    };
     let absolute_circuit_dir = if Path::new(&specified_circuit_dir).is_absolute() {
         Path::new(&specified_circuit_dir).to_path_buf()
     } else {
@@ -64,19 +89,18 @@ pub fn bindgen(
             continue;
         }
         let ext = path.extension().and_then(OsStr::to_str).unwrap_or("");
-        // Iterate over all wasm files and generate c source, then compile each source to
-        // a static library that can be called from rust
-        if ext == "wasm" {
-            // make source files with the same name as the wasm binary file
-            let circuit_name = path.file_stem().unwrap();
-            let circuit_name_compressed = circuit_name
-                .to_str()
-                .unwrap()
-                .replace("_", "")
-                .replace("-", "");
-            project_name = circuit_name_compressed;
-            // Store the circuit name and wasm path
-            circuit_map.insert(circuit_name.to_str().unwrap().to_string(), "".to_string());
+        match (&witness_adapter, ext) {
+            (WitnessAdapter::RustWitness, "wasm") | (WitnessAdapter::WitnessCalc, "dat") => {
+                let circuit_name = path.file_stem().unwrap();
+                let circuit_name_compressed = circuit_name
+                    .to_str()
+                    .unwrap()
+                    .replace("_", "")
+                    .replace("-", "");
+                project_name = circuit_name_compressed;
+                circuit_map.insert(circuit_name.to_str().unwrap().to_string(), "".to_string());
+            }
+            _ => {}
         }
     }
 
@@ -99,8 +123,9 @@ pub fn bindgen(
     }
 
     init_project(
-        &Some(adapter.as_str().to_string()),
+        &Some(proving_adapter.as_str().to_string()),
         &Some(project_name.to_string()),
+        true,
     )?;
 
     let project_dir = env::current_dir()?;
@@ -125,61 +150,110 @@ pub fn bindgen(
         Some(file) => file.contents(),
         None => return Err(anyhow::anyhow!("lib.rs not found in template")),
     };
-    let replacement = generate_rust_witness_functions(&circuit_map);
+    let replacement = generate_witness_functions(&circuit_map, &witness_adapter);
     replace_string_in_file(
         lib_rs_path.to_str().unwrap(),
         &String::from_utf8_lossy(circom_lib_rs),
         &replacement,
     )?;
 
-    // Run the build command
-    build_project(arg_mode, arg_platforms, arg_architectures, None)?;
+    if witness_adapter == WitnessAdapter::WitnessCalc {
+        let cargo_toml_path = project_dir.join("Cargo.toml");
+        let cargo_toml_str = cargo_toml_path.to_str().unwrap();
+        replace_string_in_file(
+            cargo_toml_str,
+            "mopro-ffi = { git = \"https://github.com/zkmopro/mopro.git\", features = [\"uniffi\"] }",
+            "mopro-ffi = { git = \"https://github.com/zkmopro/mopro.git\", features = [\"uniffi\", \"witnesscalc\"] }",
+        )?;
+        replace_string_in_file(cargo_toml_str, "rust-witness = \"0.1\"\n", "")?;
+        replace_string_in_file(
+            cargo_toml_str,
+            "[dependencies]\n",
+            "[dependencies]\nwitnesscalc-adapter = \"0.1\"\n",
+        )?;
+        replace_string_in_file(
+            cargo_toml_str,
+            "[build-dependencies]\n",
+            "[build-dependencies]\nwitnesscalc-adapter = \"0.1\"\n",
+        )?;
 
-    // Copy the bindings folder to the project root
+        let build_rs_path = project_dir.join("build.rs");
+        replace_string_in_file(
+            build_rs_path.to_str().unwrap(),
+            "rust_witness::transpile::transpile_wasm(\"./test-vectors/circom\".to_string());",
+            "witnesscalc_adapter::build_and_link(\"./test-vectors/circom\");",
+        )?;
+    }
+    // Run the build command
+    build_project(arg_mode, arg_platforms, arg_architectures, None, true)?;
+
+    // Copy the bindings folder to the output directory
+    fs::create_dir_all(&output_base_dir)?;
     let ios_bindings_dir = project_dir.join(IOS_BINDINGS_DIR);
     if ios_bindings_dir.exists() {
         let output_ios_bindings_dir = current_dir.join(IOS_BINDINGS_DIR);
         fs::create_dir_all(&output_ios_bindings_dir)?;
         fs_extra::dir::copy(
             &ios_bindings_dir,
-            output_ios_bindings_dir.parent().unwrap(),
+            &output_base_dir,
             &fs_extra::dir::CopyOptions::new(),
         )?;
     }
 
     let android_bindings_dir = project_dir.join(ANDROID_BINDINGS_DIR);
     if android_bindings_dir.exists() {
-        let output_android_bindings_dir = current_dir.join(ANDROID_BINDINGS_DIR);
-        fs::create_dir_all(&output_android_bindings_dir)?;
         fs_extra::dir::copy(
             &android_bindings_dir,
-            output_android_bindings_dir.parent().unwrap(),
+            &output_base_dir,
             &fs_extra::dir::CopyOptions::new(),
         )?;
     }
 
     fs::remove_dir_all(&project_dir)?;
+    style::print_green_bold(format!(
+        "✨ Bindings Generated Successfully at {} ✨",
+        output_base_dir.display()
+    ));
 
     Ok(())
 }
 
-fn generate_rust_witness_functions(circuit_map: &HashMap<String, String>) -> String {
+fn generate_witness_functions(
+    circuit_map: &HashMap<String, String>,
+    adapter: &WitnessAdapter,
+) -> String {
     let mut content = String::new();
     for key in circuit_map.keys() {
-        let rust_witness_key = key.replace("_", "").replace("-", "");
-        content.push_str(&format!("rust_witness::witness!({rust_witness_key});\n"));
+        let circuit_key = key.replace("_", "").replace("-", "");
+        match adapter {
+            WitnessAdapter::RustWitness => {
+                content.push_str(&format!("rust_witness::witness!({circuit_key});\n"));
+            }
+            WitnessAdapter::WitnessCalc => {
+                content.push_str(&format!("witnesscalc_adapter::witness!({circuit_key});\n"));
+            }
+        }
     }
 
     content.push('\n');
-    content.push_str("mopro_ffi::set_circom_circuits! {");
+    content.push_str("mopro_ffi::set_circom_circuits! {\n");
 
     for (key, value) in circuit_map {
-        let rust_witness_key = key.replace("_", "").replace("-", "");
-        content.push_str(&format!(
-            "({value:?}, mopro_ffi::witness::WitnessFn::RustWitness({rust_witness_key}_witness)),\n"
-        ));
+        let circuit_key = key.replace("_", "").replace("-", "");
+        match adapter {
+            WitnessAdapter::RustWitness => {
+                content.push_str(&format!(
+                    "({value:?}, mopro_ffi::witness::WitnessFn::RustWitness({circuit_key}_witness)),\n",
+                ));
+            }
+            WitnessAdapter::WitnessCalc => {
+                content.push_str(&format!(
+                    "({value:?}, mopro_ffi::witness::WitnessFn::WitnessCalc({circuit_key}_witness)),\n",
+                ));
+            }
+        }
     }
 
-    content.push('}');
+    content.push_str("}");
     content
 }

--- a/cli/src/bindgen.rs
+++ b/cli/src/bindgen.rs
@@ -185,7 +185,13 @@ pub fn bindgen(
         )?;
     }
     // Run the build command
-    build_project(arg_mode, arg_platforms, arg_architectures, None, true)?;
+    build_project(
+        arg_mode,
+        arg_platforms,
+        arg_architectures,
+        None,
+        true,
+    )?;
 
     // Copy the bindings folder to the output directory
     fs::create_dir_all(&output_base_dir)?;
@@ -254,6 +260,6 @@ fn generate_witness_functions(
         }
     }
 
-    content.push_str("}");
+    content.push('}');
     content
 }

--- a/cli/src/bindgen.rs
+++ b/cli/src/bindgen.rs
@@ -137,12 +137,14 @@ pub fn bindgen(
     if test_vectors_dir.exists() {
         fs::remove_dir_all(&test_vectors_dir)?;
     }
-    // Copy the entire directory
-    fs_extra::dir::copy(
-        &absolute_circuit_dir,
-        test_vectors_dir.parent().unwrap(),
-        &fs_extra::dir::CopyOptions::new(),
-    )?;
+    // Create the destination directory
+    fs::create_dir_all(&test_vectors_dir)?;
+
+    // Copy the contents of the circuit directory into test-vectors/circom
+    // This ensures files end up in the correct location regardless of source dir name
+    let mut copy_options = fs_extra::dir::CopyOptions::new();
+    copy_options.content_only = true;
+    fs_extra::dir::copy(&absolute_circuit_dir, &test_vectors_dir, &copy_options)?;
 
     let lib_rs_path = project_dir.join("src").join("lib.rs");
     let template_dir: Dir = include_dir!("$CARGO_MANIFEST_DIR/src/template/circom");

--- a/cli/src/bindgen.rs
+++ b/cli/src/bindgen.rs
@@ -187,13 +187,7 @@ pub fn bindgen(
         )?;
     }
     // Run the build command
-    build_project(
-        arg_mode,
-        arg_platforms,
-        arg_architectures,
-        None,
-        true,
-    )?;
+    build_project(arg_mode, arg_platforms, arg_architectures, None, true)?;
 
     // Copy the bindings folder to the output directory
     fs::create_dir_all(&output_base_dir)?;

--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -29,6 +29,7 @@ pub fn build_project(
     arg_platforms: &Option<Vec<String>>,
     arg_architectures: &Option<Vec<String>>,
     auto_update_flag: Option<bool>,
+    quiet: bool,
 ) -> Result<()> {
     // Detect `Cargo.toml` file before starting build process
     let current_dir = env::current_dir()?;
@@ -115,6 +116,7 @@ pub fn build_project(
             arg_platforms,
             arg_architectures,
             auto_update_flag,
+            quiet,
         )?;
         return Ok(());
     }
@@ -132,6 +134,7 @@ pub fn build_project(
                 arg_platforms,
                 arg_architectures,
                 auto_update_flag,
+                quiet,
             )?;
             return Ok(());
         }
@@ -181,6 +184,7 @@ pub fn build_project(
                 arg_platforms,
                 arg_architectures,
                 auto_update_flag,
+                quiet,
             )?;
             return Ok(());
         }
@@ -227,7 +231,9 @@ pub fn build_project(
         }?;
     }
 
-    print_binding_message(&platform.platforms)?;
+    if !quiet {
+        print_binding_message(&platform.platforms)?;
+    }
     handle_auto_update(&config_path, &mut config, auto_update_flag)?;
     print_build_success_message();
 

--- a/cli/src/create/utils.rs
+++ b/cli/src/create/utils.rs
@@ -169,6 +169,7 @@ pub fn check_bindings(project_dir: &Path, platform: Platform) -> Result<Option<P
             &Some(vec![platform.as_str().to_string()]),
             &None,
             Some(false),
+            false,
         )?;
 
         if bindings_dir.exists() && fs::read_dir(&bindings_dir)?.count() > 0 {

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -24,6 +24,7 @@ trait ProvingSystem {
 pub fn init_project(
     arg_adapter: &Option<String>,
     arg_project_name: &Option<String>,
+    quiet: bool,
 ) -> anyhow::Result<()> {
     let project_name: String = match arg_project_name.as_deref() {
         None => Input::with_theme(&ColorfulTheme::default())
@@ -96,7 +97,10 @@ pub fn init_project(
     write_config(&config_path, &config)?;
 
     // Print out the instructions
-    print_init_instructions(project_name);
+    if !quiet {
+        // Print out the instructions
+        print_init_instructions(project_name);
+    }
 
     Ok(())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -144,6 +144,13 @@ fn main() {
                 print::print_build_success_message();
                 return;
             }
+            let auto_update_flag = if *auto_update {
+                Some(true)
+            } else if *no_auto_update {
+                Some(false)
+            } else {
+                None
+            };
             match build::build_project(mode, platforms, architectures, auto_update_flag, false) {
                 Ok(_) => {}
                 Err(e) => style::print_red_bold(format!("Failed to build project: {e:?}")),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -144,13 +144,7 @@ fn main() {
                 print::print_build_success_message();
                 return;
             }
-            match build::build_project(
-                mode,
-                platforms,
-                architectures,
-                auto_update_flag,
-                false,
-            ) {
+            match build::build_project(mode, platforms, architectures, auto_update_flag, false) {
                 Ok(_) => {}
                 Err(e) => style::print_red_bold(format!("Failed to build project: {e:?}")),
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -102,6 +102,13 @@ enum Commands {
             help = "path to the circuit directory (it should contain `.wtns` and `.zkey` files)"
         )]
         circuit_dir: Option<String>,
+        #[arg(
+            long,
+            help = "Specify the witness generator adapter (e.g., 'rust-witness' or 'witnesscalc')."
+        )]
+        adapter: Option<String>,
+        #[arg(long, help = "Specify the output directory for bindings.")]
+        output_dir: Option<String>,
         #[arg(long, help = "Show instruction message for build")]
         show: bool,
     },
@@ -120,7 +127,7 @@ fn main() {
                 print::print_init_instructions("<PROJECT NAME>".to_string());
                 return;
             }
-            match init::init_project(adapter, project_name) {
+            match init::init_project(adapter, project_name, false) {
                 Ok(_) => {}
                 Err(e) => style::print_red_bold(format!("Failed to initialize project: {e:?}")),
             }
@@ -143,7 +150,7 @@ fn main() {
                 _ => None,
             };
 
-            match build::build_project(mode, platforms, architectures, auto_update_flag) {
+            match build::build_project(mode, platforms, architectures, auto_update_flag, false) {
                 Ok(_) => {}
                 Err(e) => style::print_red_bold(format!("Failed to build project: {e:?}")),
             }
@@ -194,12 +201,21 @@ fn main() {
             architectures,
             circuit_dir,
             show,
+            adapter,
+            output_dir,
         } => {
             if *show {
                 // TODO: print bindgen instructions
                 return;
             }
-            match bindgen::bindgen(mode, platforms, architectures, circuit_dir) {
+            match bindgen::bindgen(
+                mode,
+                platforms,
+                architectures,
+                circuit_dir,
+                adapter,
+                output_dir,
+            ) {
                 Ok(_) => {}
                 Err(e) => style::print_red_bold(format!("Failed to generate bindings: {e:?}")),
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -144,13 +144,13 @@ fn main() {
                 print::print_build_success_message();
                 return;
             }
-            let auto_update_flag = match (*auto_update, *no_auto_update) {
-                (true, _) => Some(true),
-                (_, true) => Some(false),
-                _ => None,
-            };
-
-            match build::build_project(mode, platforms, architectures, auto_update_flag, false) {
+            match build::build_project(
+                mode,
+                platforms,
+                architectures,
+                auto_update_flag,
+                false,
+            ) {
                 Ok(_) => {}
                 Err(e) => style::print_red_bold(format!("Failed to build project: {e:?}")),
             }


### PR DESCRIPTION
Fixes #517 

#$ Summary
- Added new `--adapter` and `--output-dir` options to `mopro bindgen`, enabling witness generation via `witnesscalc` and writing bindings to a chosen location.
- Introduced a quiet mode for initialization and build steps to suppress instructional output while still allowing regular usage to display messages.
- Updated documentation and README to describe the new witness generator and output directory options for `bindgen`