### PR TITLE
FFI: binding naming consistency for mobile platforms

### DIFF
--- a/test-e2e/tests/bindings/test_circom_keccak.swift
+++ b/test-e2e/tests/bindings/test_circom_keccak.swift
@@ -1,5 +1,5 @@
 import Foundation
-import mopro_bindings
+import MoproBindings
 
 // Helper function to convert bytes to bits
 func bytesToBits(bytes: [UInt8]) -> [String] {

--- a/test-e2e/tests/bindings/test_circom_multiplier2.swift
+++ b/test-e2e/tests/bindings/test_circom_multiplier2.swift
@@ -1,5 +1,5 @@
 import Foundation
-import mopro_bindings
+import MoproBindings
 
 func serializeOutputs(_ stringArray: [String]) -> [UInt8] {
   var bytesArray: [UInt8] = []

--- a/test-e2e/tests/bindings/test_circom_multiplier2_bls.swift
+++ b/test-e2e/tests/bindings/test_circom_multiplier2_bls.swift
@@ -1,5 +1,5 @@
 import Foundation
-import mopro_bindings
+import MoproBindings
 
 func serializeOutputs(_ stringArray: [String]) -> [UInt8] {
   var bytesArray: [UInt8] = []

--- a/test-e2e/tests/bindings/test_gemini_fibonacci.swift
+++ b/test-e2e/tests/bindings/test_gemini_fibonacci.swift
@@ -1,5 +1,5 @@
 import Foundation
-import mopro_bindings
+import MoproBindings
 
 do {
   let srsPath = "../../../test-vectors/halo2/gemini_fibonacci_srs.bin"

--- a/test-e2e/tests/bindings/test_halo2_keccak256.swift
+++ b/test-e2e/tests/bindings/test_halo2_keccak256.swift
@@ -1,5 +1,5 @@
 import Foundation
-import mopro_bindings
+import MoproBindings
 
 do {
   let srsPath = "../../../test-vectors/halo2/keccak256_srs.bin"

--- a/test-e2e/tests/bindings/test_hyperplonk_fibonacci.swift
+++ b/test-e2e/tests/bindings/test_hyperplonk_fibonacci.swift
@@ -1,5 +1,5 @@
 import Foundation
-import mopro_bindings
+import MoproBindings
 
 do {
   let srsPath = "../../../test-vectors/halo2/hyperplonk_fibonacci_srs.bin"

--- a/test-e2e/tests/bindings/test_noir_multiplier2.kts
+++ b/test-e2e/tests/bindings/test_noir_multiplier2.kts
@@ -1,5 +1,5 @@
 import java.io.File
-import uniffi.mopro_bindings.*
+import uniffi.MoproBindings.*
 
 fun testNoirMultiplier2() {
     try {

--- a/test-e2e/tests/bindings/test_noir_multiplier2.swift
+++ b/test-e2e/tests/bindings/test_noir_multiplier2.swift
@@ -1,5 +1,5 @@
 import Foundation
-import mopro_bindings
+import MoproBindings
 
 // Test the generateNoirProof and verifyNoirProof functions
 func testNoirMultiplier2() {

--- a/test-e2e/tests/bindings/test_plonk_fibonacci.swift
+++ b/test-e2e/tests/bindings/test_plonk_fibonacci.swift
@@ -1,5 +1,5 @@
 import Foundation
-import mopro_bindings
+import MoproBindings
 
 do {
   let srsPath = "../../../test-vectors/halo2/plonk_fibonacci_srs.bin"


### PR DESCRIPTION
## Summary

- Updates project name formatting to use PascalCase for mobile platform naming conventions
- Standardizes import statements across test files to use consistent naming

This ensures FFI bindings follow mobile platform naming conventions where:
- iOS frameworks use PascalCase (e.g., MoproBindings)
- Android packages follow similar capitalization patterns

## Impact

- Breaking Change: Projects using the old mopro_bindings import will need to
update to MoproBindings
- Compatibility: Improves consistency with mobile platform naming
conventions
- Developer Experience: More intuitive import names for mobile developers

 ## Related Work
- Completes the FFI naming convention improvements started in PR #548
- Closes #500