### PR TITLE
fix: resolve React Native compilation issues and add CI build checks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -382,6 +382,107 @@ jobs:
             name: android-test-report
             path: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}/android/app/build/reports/androidTests/connected/debug/
 
+  cli_create_react_native:
+    needs: cli_build
+    strategy:
+      fail-fast: false
+      matrix:
+        adapter: [circom, halo2, noir]
+    runs-on: macos-14
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo_full_name
+    steps:
+      - uses: actions/checkout@v5
+
+      # Build mopro example project for iOS + Android first, and create RN frameworks
+      - name: Prepare template project
+        uses: ./.github/actions/mopro-init-project
+        with:
+          artifact-name: mopro-bin-macOS
+          adapter: ${{ matrix.adapter }}
+          project-name: mopro-example-${{ matrix.adapter }}
+          destination: ${{ runner.temp }}
+
+      - name: Build iOS (debug; device+sim arm64 only)
+        working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}
+        run: |
+          "$GITHUB_WORKSPACE/bin/mopro" build \
+            --mode debug \
+            --platforms ios \
+            --architectures aarch64-apple-ios aarch64-apple-ios-sim
+
+      - name: Build Android (debug, x86_64)
+        working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}
+        run: |
+          "$GITHUB_WORKSPACE/bin/mopro" build \
+            --mode debug \
+            --platforms android \
+            --architectures x86_64-linux-android
+
+      - name: Clean mopro build dir
+        run: rm -rf ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}/build
+
+      - name: Create React Native frameworks
+        working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}
+        run: $GITHUB_WORKSPACE/bin/mopro create --framework react-native
+
+      # ---- Node & deps ----
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install JS packages
+        working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}/react-native
+        run: npm ci
+
+      - name: Expo prebuild (generate ios/ & android/)
+        working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}/react-native
+        env:
+          EXPO_NO_INTERACTIVE: '1'
+        run: npx expo prebuild --clean
+
+      # ---- iOS build (headless) ----
+      - name: Install iOS Pods
+        working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}/react-native/ios
+        run: pod install
+
+      - name: Build iOS (Debug, iphonesimulator)
+        working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}/react-native
+        run: |
+          xcodebuild \
+            -workspace ios/*.xcworkspace \
+            -scheme reactnativeapp \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            ARCHS=arm64 EXCLUDED_ARCHS='x86_64' ONLY_ACTIVE_ARCH=YES \
+            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" \
+            build
+
+      # ---- Android build (headless) ----
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Android SDK (cmdline only)
+        uses: android-actions/setup-android@v3
+
+      - name: Assemble Android Debug (no emulator)
+        working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}/react-native/android
+        run: ./gradlew --no-daemon --stacktrace assembleDebug
+
+      - name: Upload native build outputs (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rn-build-outputs-${{ matrix.adapter }}
+          path: |
+            ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}/react-native/ios/build/**/*.log
+            ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}/react-native/android/app/build/outputs/**
+          if-no-files-found: ignore
+
   cli_build_web:
       needs: cli_build
       strategy:

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -71,6 +71,10 @@ pub fn init_project(
         adapter_sel.lib_template(lib_rs_path);
     }
 
+    if let Some(test_bindings_dir_path) = project_dir.join("tests").join("bindings").to_str() {
+        replace_test_bindings_lib_import(test_bindings_dir_path, project_name.as_str())?;
+    }
+
     // Store selection
     let config_path = project_dir.join("Config.toml");
 
@@ -93,6 +97,50 @@ pub fn init_project(
     if !quiet {
         // Print out the instructions
         print_init_instructions(project_name);
+    }
+
+    Ok(())
+}
+
+/// Replace the placeholder import lines in the test bindings files with the actual import statements
+/// based on the project name and file type (Kotlin or Swift).
+fn replace_test_bindings_lib_import(test_bindings_dir: &str, project_name: &str) -> Result<()> {
+    let project_lib_name = project_name.replace('-', "_");
+
+    // We expect a structure of `tests/bindings/<adapter>/*.(kts|swift)`
+    for bundle in fs::read_dir(test_bindings_dir)? {
+        let bundle = bundle?;
+        let bundle_path = bundle.path();
+
+        if !bundle_path.is_dir() {
+            continue;
+        }
+
+        for file in fs::read_dir(&bundle_path)? {
+            let file = file?;
+            let file_path = file.path();
+
+            if !file_path.is_file() {
+                continue;
+            }
+
+            let target = "// GENERATED LIB IMPORT PLACEHOLDER";
+            let replacement = match file_path.extension().and_then(|ext| ext.to_str()) {
+                Some("kts") => Some(format!("import uniffi.{}.*", project_lib_name)),
+                Some("swift") => Some(format!("import {}", project_lib_name)),
+                _ => None,
+            };
+
+            if let Some(line) = replacement {
+                replace_string_in_file(
+                    file_path
+                        .to_str()
+                        .ok_or(anyhow::anyhow!("Invalid test binding file path"))?,
+                    target,
+                    &line,
+                )?;
+            }
+        }
     }
 
     Ok(())

--- a/cli/src/init/write_toml.rs
+++ b/cli/src/init/write_toml.rs
@@ -6,7 +6,6 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-name = "mopro"
 crate-type = ["lib", "cdylib", "staticlib"]
 
 # Adapters for different proof systems

--- a/cli/src/template/init/tests/bindings/circom/test_multiplier2.kts
+++ b/cli/src/template/init/tests/bindings/circom/test_multiplier2.kts
@@ -1,4 +1,4 @@
-import uniffi.mopro.*
+// GENERATED LIB IMPORT PLACEHOLDER
 
 try {
     var zkeyPath = "./test-vectors/circom/multiplier2_final.zkey"

--- a/cli/src/template/init/tests/bindings/circom/test_multiplier2.swift
+++ b/cli/src/template/init/tests/bindings/circom/test_multiplier2.swift
@@ -1,5 +1,5 @@
 import Foundation
-import mopro
+// GENERATED LIB IMPORT PLACEHOLDER
 
 do {
     let zkeyPath = "../../../test-vectors/circom/multiplier2_final.zkey"

--- a/cli/src/template/init/tests/bindings/halo2/test_gemini_fibonacci.kts
+++ b/cli/src/template/init/tests/bindings/halo2/test_gemini_fibonacci.kts
@@ -1,4 +1,4 @@
-import uniffi.mopro.*
+// GENERATED LIB IMPORT PLACEHOLDER
 
 try {
     val srsPath = "./test-vectors/halo2/gemini_fibonacci_srs.bin"

--- a/cli/src/template/init/tests/bindings/halo2/test_gemini_fibonacci.swift
+++ b/cli/src/template/init/tests/bindings/halo2/test_gemini_fibonacci.swift
@@ -1,5 +1,5 @@
 import Foundation
-import mopro
+// GENERATED LIB IMPORT PLACEHOLDER
 
 do {
     let srsPath = "../../../test-vectors/halo2/gemini_fibonacci_srs.bin"

--- a/cli/src/template/init/tests/bindings/halo2/test_hyperplonk_fibonacci.kts
+++ b/cli/src/template/init/tests/bindings/halo2/test_hyperplonk_fibonacci.kts
@@ -1,4 +1,4 @@
-import uniffi.mopro.*
+// GENERATED LIB IMPORT PLACEHOLDER
 
 try {
     val srsPath = "./test-vectors/halo2/hyperplonk_fibonacci_srs.bin"

--- a/cli/src/template/init/tests/bindings/halo2/test_hyperplonk_fibonacci.swift
+++ b/cli/src/template/init/tests/bindings/halo2/test_hyperplonk_fibonacci.swift
@@ -1,5 +1,5 @@
 import Foundation
-import mopro
+// GENERATED LIB IMPORT PLACEHOLDER
 
 do {
     let srsPath = "../../../test-vectors/halo2/hyperplonk_fibonacci_srs.bin"

--- a/cli/src/template/init/tests/bindings/halo2/test_plonk_fibonacci.kts
+++ b/cli/src/template/init/tests/bindings/halo2/test_plonk_fibonacci.kts
@@ -1,4 +1,4 @@
-import uniffi.mopro.*
+// GENERATED LIB IMPORT PLACEHOLDER
 
 try {
     val srsPath = "./test-vectors/halo2/plonk_fibonacci_srs.bin"

--- a/cli/src/template/init/tests/bindings/halo2/test_plonk_fibonacci.swift
+++ b/cli/src/template/init/tests/bindings/halo2/test_plonk_fibonacci.swift
@@ -1,5 +1,5 @@
 import Foundation
-import mopro
+// GENERATED LIB IMPORT PLACEHOLDER
 
 do {
     let srsPath = "../../../test-vectors/halo2/plonk_fibonacci_srs.bin"


### PR DESCRIPTION
## Summary
- Fixed generated Swift/Kotlin binding tests:
  - Replaced the default `mopro` import with the project-specific library name.
  - Updated the CLI `init` flow to rewrite the `// GENERATED LIB IMPORT` placeholder for both:
    - Swift → `import <project_name>`
    - Kotlin → `import uniffi.<project_name>.*`
- Added a CI job that ensures React Native apps created via `mopro` can be built successfully:
  - Runs `expo prebuild` to generate native projects.
  - Verifies iOS builds headlessly with `xcodebuild`.
  - Verifies Android builds headlessly with Gradle (`assembleDebug`).


  This fixes #567 and makes sure that we never miss similar issues in the future by implementing #570.
