### PR TITLE
Add ark-circom-witnesscalc integration (work-in-progress)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-circom-witnesscalc"
+version = "0.1.0"
+source = "git+https://github.com/HarryR/ark-circom-witnesscalc.git#590afa5d354be1ff5eaa2d16bf3831c15614e1f8"
+dependencies = [
+ "anyhow",
+ "ark-bn254",
+ "ark-crypto-primitives",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-groth16",
+ "ark-relations",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "byteorder",
+ "circom-witnesscalc 0.2.2",
+ "hex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ark-crypto-primitives"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,11 +1140,12 @@ dependencies = [
 
 [[package]]
 name = "circom-prover"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
  "ark-bn254",
+ "ark-circom-witnesscalc",
  "ark-crypto-primitives",
  "ark-ec",
  "ark-ff 0.5.0",
@@ -1133,7 +1155,7 @@ dependencies = [
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
  "byteorder",
- "circom-witnesscalc",
+ "circom-witnesscalc 0.2.1",
  "hex-literal",
  "num",
  "num-bigint",
@@ -1153,6 +1175,34 @@ name = "circom-witnesscalc"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3fb734f91de7e7002678ea3238fddfd4ee7afd33e9ed975176f4a94794a55a"
+dependencies = [
+ "anyhow",
+ "ark-bn254",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "bindgen",
+ "byteorder",
+ "indicatif",
+ "libc",
+ "memmap2",
+ "num-bigint",
+ "num-traits",
+ "prost",
+ "prost-build",
+ "rand 0.8.5",
+ "ruint",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.16",
+ "winnow 0.7.12",
+ "wtns-file",
+]
+
+[[package]]
+name = "circom-witnesscalc"
+version = "0.2.2"
+source = "git+https://github.com/HarryR/circom-witnesscalc#40cfe1e641b267265dd252921de78b52915ed3fc"
 dependencies = [
  "anyhow",
  "ark-bn254",

--- a/circom-prover/Cargo.toml
+++ b/circom-prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "circom-prover"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Circom prover is a Rust library for generating and verifying proofs for Circom circuits."
 license = "MIT OR Apache-2.0"
@@ -15,6 +15,11 @@ name = "circom_prover"
 [features]
 default = ["rustwitness", "arkworks"]
 beta = ["witnesscalc", "rapidsnark"]
+
+ark-circom-witnesscalc = [
+    "dep:ark-circom-witnesscalc",
+    "arkworks"
+]
 
 # Witness Generation
 rustwitness = ["rust-witness"]
@@ -86,6 +91,8 @@ ark-poly = { version = "=0.5.0", default-features = false, features = [
     "parallel",
 ], optional = true }
 rand = { version = "0.8", features = ["std"] }
+
+ark-circom-witnesscalc = { git = "https://github.com/HarryR/ark-circom-witnesscalc.git", optional = true }
 
 # witnesscalc-adapter
 witnesscalc-adapter = { version = "0.1", optional = true }

--- a/circom-prover/src/lib.rs
+++ b/circom-prover/src/lib.rs
@@ -13,6 +13,9 @@ use witness::WitnessFn;
 #[cfg(feature = "witnesscalc")]
 pub use witnesscalc_adapter;
 
+#[cfg(feature = "ark-circom-witnesscalc")]
+pub use ark_circom_witnesscalc;
+
 #[cfg(feature = "circom-witnesscalc")]
 #[doc(hidden)]
 pub mod __macro_deps {
@@ -38,6 +41,22 @@ impl CircomProver {
 
     pub fn verify(proof_lib: ProofLib, proof: CircomProof, zkey_path: String) -> Result<bool> {
         prover::verify(proof_lib, zkey_path, proof)
+    }
+
+    #[cfg(feature = "ark-circom-witnesscalc")]
+    pub fn prove_to_json(
+        json_input_str: &str,
+        ark_pkey_data: &[u8],
+        cwc_graph_data: &[u8],
+        r1cs_data: &[u8],
+    ) -> Result<String> {
+        let (proof, public_inputs) = ark_circom_witnesscalc::proof_oneshot(json_input_str, ark_pkey_data, cwc_graph_data, r1cs_data);
+        ark_circom_witnesscalc::proof_to_json(&proof, &public_inputs)
+    }
+
+    #[cfg(feature = "ark-circom-witnesscalc")]
+    pub fn verify_json(vkey_json: &str, proof_json: &str) -> Result<bool> {
+        ark_circom_witnesscalc::verify_proof_json(vkey_json, proof_json)
     }
 }
 


### PR DESCRIPTION
This is a small patch to import the two prove & verify functions from my [ark-circom-witnesscalc](https://github.com/HarryR/ark-circom-witnesscalc), as a quick demo.

The reason behind this patch is:

 * I wanted to use MoPro on mobile web, not native
 * snarkjs was hanging when doing the groth16 setup for a complex circuit, so I used arkworks for trusted setup (runs almost instantly)
 * arkworks circom-prover used wasix to run the snarkjs WASM witness calculator, which made building for WASM complicated & slow
 * circom-witnesscalc used bindgen, which made WASM compilation difficult/annoying (no C headers for wasm32-unknown, C bindings were unnecessary when linking directly against it from Rust)
 * zkey loading isn't zero-copy for arkworks, requires filesystem access (not available on browser WASM)
 * wanted to use rayon for multithreading with browser WASM

To fix this I:

 * Made a small patch to circom-witnesscalc, to make building for browser WASM possible
   * https://github.com/HarryR/circom-witnesscalc
 * Made a small repo combining arkworks & my circom-witnesscalc branch
   * https://github.com/HarryR/ark-circom-witnesscalc 
   * Accepts JSON, responds with a JSON proof
   * Pass data (proving key, r1cs, witnesscalc graph) directly as bytes instead of loading from filesystem
   * Some small utilities, and library functions e.g. proof_to_json, verifying_key_from_json and so on which input/output in Circom JSON format.

This is a work in progress, and I would like feedback on how best to integrate this properly with MoPro, as it stands I can produce a single .wasm file containing the proving key, the witness generation runs quickly, and with rayon it can use all CPU cores while proving.

Unfortunately I ran into a small bug with circom-witnesscalc, where if the optimizer is enabled (anything aside form `-O0`) the wires/signals get confused, I will need to fix this. I also noticed that I had to disable the additional 'optimizer' stage in wasm-pack, as that resulted in nearly an order of magnitude increase in proving time, e.g. 47s vs 10s for a 100k constraint circuit on a single thread.