### PR TITLE
refactor: update adapter methods to return results and handle errors

### DIFF
--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -58,17 +58,17 @@ pub fn init_project(
 
     if let Some(cargo_toml_path) = project_dir.join("Cargo.toml").to_str() {
         replace_project_name(cargo_toml_path, &project_name)?;
-        adapter_sel.dep_template(cargo_toml_path);
-        adapter_sel.build_dep_template(cargo_toml_path);
-        adapter_sel.dev_dep_template(cargo_toml_path);
+        adapter_sel.dep_template(cargo_toml_path)?;
+        adapter_sel.build_dep_template(cargo_toml_path)?;
+        adapter_sel.dev_dep_template(cargo_toml_path)?;
     }
 
     if let Some(build_rs_path) = project_dir.join("build.rs").to_str() {
-        adapter_sel.build_template(build_rs_path);
+        adapter_sel.build_template(build_rs_path)?;
     }
 
     if let Some(lib_rs_path) = project_dir.join("src").join("lib.rs").to_str() {
-        adapter_sel.lib_template(lib_rs_path);
+        adapter_sel.lib_template(lib_rs_path)?;
     }
 
     if let Some(test_bindings_dir_path) = project_dir.join("tests").join("bindings").to_str() {

--- a/cli/src/init/adapter.rs
+++ b/cli/src/init/adapter.rs
@@ -72,72 +72,77 @@ impl AdapterSelector {
         }
     }
 
-    pub fn dep_template(&self, cargo_toml_path: &str) {
+    pub fn dep_template(&self, cargo_toml_path: &str) -> anyhow::Result<()> {
         if self.contains(Adapter::Circom) {
-            Circom::dep_template(cargo_toml_path).unwrap();
+            Circom::dep_template(cargo_toml_path)?;
         }
         if self.contains(Adapter::Halo2) {
-            Halo2::dep_template(cargo_toml_path).unwrap();
+            Halo2::dep_template(cargo_toml_path)?;
         }
         if self.contains(Adapter::Noir) {
-            Noir::dep_template(cargo_toml_path).unwrap();
+            Noir::dep_template(cargo_toml_path)?;
         }
+        Ok(())
     }
 
-    pub fn build_dep_template(&self, cargo_toml_path: &str) {
+    pub fn build_dep_template(&self, cargo_toml_path: &str) -> anyhow::Result<()> {
         if self.contains(Adapter::Circom) {
-            Circom::build_dep_template(cargo_toml_path).unwrap();
+            Circom::build_dep_template(cargo_toml_path)?;
         }
         if self.contains(Adapter::Halo2) {
-            Halo2::build_dep_template(cargo_toml_path).unwrap();
+            Halo2::build_dep_template(cargo_toml_path)?;
         }
         if self.contains(Adapter::Noir) {
-            Noir::build_dep_template(cargo_toml_path).unwrap();
+            Noir::build_dep_template(cargo_toml_path)?;
         }
+        Ok(())
     }
 
-    pub fn dev_dep_template(&self, cargo_toml_path: &str) {
+    pub fn dev_dep_template(&self, cargo_toml_path: &str) -> anyhow::Result<()> {
         if self.contains(Adapter::Circom) {
-            Circom::dev_dep_template(cargo_toml_path).unwrap();
+            Circom::dev_dep_template(cargo_toml_path)?;
         }
         if self.contains(Adapter::Halo2) {
-            Halo2::dev_dep_template(cargo_toml_path).unwrap();
+            Halo2::dev_dep_template(cargo_toml_path)?;
         }
         if self.contains(Adapter::Noir) {
-            Noir::dev_dep_template(cargo_toml_path).unwrap();
+            Noir::dev_dep_template(cargo_toml_path)?;
         }
+        Ok(())
     }
 
-    pub fn lib_template(&self, lib_rs_path: &str) {
+    pub fn lib_template(&self, lib_rs_path: &str) -> anyhow::Result<()> {
         if self.contains(Adapter::Circom) {
-            Circom::lib_template(lib_rs_path).unwrap();
+            Circom::lib_template(lib_rs_path)?;
         } else {
-            Circom::lib_stub_template(lib_rs_path).unwrap();
+            Circom::lib_stub_template(lib_rs_path)?;
         }
 
         if self.contains(Adapter::Halo2) {
-            Halo2::lib_template(lib_rs_path).unwrap();
+            Halo2::lib_template(lib_rs_path)?;
         } else {
-            Halo2::lib_stub_template(lib_rs_path).unwrap();
+            Halo2::lib_stub_template(lib_rs_path)?;
         }
 
         if self.contains(Adapter::Noir) {
-            Noir::lib_template(lib_rs_path).unwrap();
+            Noir::lib_template(lib_rs_path)?;
         } else {
-            Noir::lib_stub_template(lib_rs_path).unwrap();
+            Noir::lib_stub_template(lib_rs_path)?;
         }
+        Ok(())
     }
 
-    pub fn build_template(&self, build_rs_path: &str) {
+    pub fn build_template(&self, build_rs_path: &str) -> anyhow::Result<()> {
         if self.contains(Adapter::Circom) {
-            Circom::build_template(build_rs_path).unwrap();
+            Circom::build_template(build_rs_path)?;
         }
         if self.contains(Adapter::Halo2) {
-            Halo2::build_template(build_rs_path).unwrap();
+            Halo2::build_template(build_rs_path)?;
         }
         if self.contains(Adapter::Noir) {
-            Noir::build_template(build_rs_path).unwrap();
+            Noir::build_template(build_rs_path)?;
         }
+        Ok(())
     }
 
     pub fn contains(&self, adapter: Adapter) -> bool {

--- a/cli/src/template/init/tests/noir.rs
+++ b/cli/src/template/init/tests/noir.rs
@@ -1,0 +1,3 @@
+mopro_ffi::uniffi_setup!();
+
+// TODO: Add tests for noir


### PR DESCRIPTION
* Changed adapter methods in `adapter.rs` to return `anyhow::Result<()>` for better error handling.
* Updated calls to these methods in `init.rs` to propagate errors correctly.
* Added a new test file for Noir templates to facilitate future testing.
* fix #577 