### PR TITLE
docs: fix typo

### DIFF
--- a/docs/blog/2025-01-06-2024-retro.md
+++ b/docs/blog/2025-01-06-2024-retro.md
@@ -44,7 +44,7 @@ Please refer to the following resources to learn how to use Mopro for building W
 
 ### Expanding Compatibility with General Rust Functions
 
-We realized that generating and verifying proofs alone isn’t sufficient for application developers. To address this, we made the Mopro template compatible with any Rust crate or function, allowing developer to extend the FFI interface directly through Rust code.
+We realized that generating and verifying proofs alone isn’t sufficient for application developers. To address this, we made the Mopro template compatible with any Rust crate or function, allowing developers to extend the FFI interface directly through Rust code.
 
 For instance, if a developer needs a Poseidon hash function but neither Swift nor Kotlin provides a Poseidon hash library, they can integrate a Rust Poseidon crate. First, they define the function API in Rust, such as:
 


### PR DESCRIPTION
<img width="932" height="128" alt="Снимок экрана 2025-09-28 в 15 15 10" src="https://github.com/user-attachments/assets/39bd29c6-feb0-497d-bc19-97f816145fc9" />
developer  → developers