### PR TITLE
feat: update dependencies and add Flutter support in mopro-ffi

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -160,11 +160,11 @@ jobs:
           project-name: mopro-example-${{ matrix.adapter }}
           destination: ${{ runner.temp }}
 
-      - name: Build iOS (debug; device+sim arm64 only)
+      - name: Build iOS (release; device+sim arm64 only)
         working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}
         run: |
           "$GITHUB_WORKSPACE/bin/mopro" build \
-            --mode debug \
+            --mode release \
             --platforms ios \
             --architectures aarch64-apple-ios aarch64-apple-ios-sim
 
@@ -343,11 +343,11 @@ jobs:
             project-name: mopro-example-${{ matrix.adapter }}
             destination: ${{ runner.temp }}
 
-        - name: Build Android (debug, x86_64)
+        - name: Build Android (release, x86_64)
           working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}
           run: |
             "$GITHUB_WORKSPACE/bin/mopro" build \
-              --mode debug \
+              --mode release \
               --platforms android \
               --architectures x86_64-linux-android
 
@@ -410,11 +410,11 @@ jobs:
             project-name: mopro-example-${{ matrix.adapter }}
             destination: ${{ runner.temp }}
 
-        - name: Build Flutter (debug)
+        - name: Build Flutter (release)
           working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}
           run: |
             "$GITHUB_WORKSPACE/bin/mopro" build \
-              --mode debug \
+              --mode release \
               --platforms flutter 
 
         - name: Clean the `build` dir to save space
@@ -449,19 +449,19 @@ jobs:
           project-name: mopro-example-${{ matrix.adapter }}
           destination: ${{ runner.temp }}
 
-      - name: Build iOS (debug; device+sim arm64 only)
+      - name: Build iOS (release; device+sim arm64 only)
         working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}
         run: |
           "$GITHUB_WORKSPACE/bin/mopro" build \
-            --mode debug \
+            --mode release \
             --platforms ios \
             --architectures aarch64-apple-ios aarch64-apple-ios-sim
 
-      - name: Build Android (debug, x86_64)
+      - name: Build Android (release, x86_64)
         working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}
         run: |
           "$GITHUB_WORKSPACE/bin/mopro" build \
-            --mode debug \
+            --mode release \
             --platforms android \
             --architectures x86_64-linux-android
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -397,6 +397,11 @@ jobs:
       steps:
         - uses: actions/checkout@v5
 
+        - uses: subosito/flutter-action@v2
+          with:
+            flutter-version: '3.35.4'
+            channel: 'stable'
+
         - name: Prepare template project
           uses: ./.github/actions/mopro-init-project
           with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -385,6 +385,44 @@ jobs:
           with:
             name: android-test-report
             path: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}/android/app/build/reports/androidTests/connected/debug/
+  
+  cli_build_flutter:
+      needs: cli_build
+      strategy:
+        fail-fast: false
+        matrix:
+          adapter: [circom, halo2, noir]
+      runs-on: ubuntu-latest
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+      steps:
+        - uses: actions/checkout@v5
+
+        - name: Prepare template project
+          uses: ./.github/actions/mopro-init-project
+          with:
+            artifact-name: mopro-bin-${{ runner.os }}
+            adapter: ${{ matrix.adapter }}
+            project-name: mopro-example-${{ matrix.adapter }}
+            destination: ${{ runner.temp }}
+
+        - name: Build Flutter (debug)
+          working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}
+          run: |
+            "$GITHUB_WORKSPACE/bin/mopro" build \
+              --mode debug \
+              --platforms flutter 
+
+        - name: Clean the `build` dir to save space
+          run: rm -rf ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}/build
+
+        - name: Create Flutter framework
+          working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}
+          run: |
+            "$GITHUB_WORKSPACE/bin/mopro" create --framework flutter
+
+        - name: Build flutter app
+          working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}
+          run: cd flutter && flutter pub get
 
   cli_create_react_native:
     needs: cli_build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -654,18 +654,7 @@ jobs:
           echo "Check override chrome version"
           google-chrome --version
           cd mopro-wasm
-          # Backup original Cargo.toml to prevent workspace corruption
-          cp ../Cargo.toml ../Cargo.toml.backup
-          # Temporarily remove packages with noir dependencies from workspace
-          sed -i '/"mopro-ffi",/d' ../Cargo.toml
-          sed -i '/"test-e2e",/d' ../Cargo.toml
-          sed -i '/"cli",/d' ../Cargo.toml
-          # Run tests and restore workspace even on failure
-          (wasm-pack test --chrome --chromedriver $CHROMEDRIVER_BIN --headless -- --all-features) || TEST_EXIT_CODE=$?
-          # Restore original Cargo.toml
-          mv ../Cargo.toml.backup ../Cargo.toml
-          # Exit with original test result
-          exit ${TEST_EXIT_CODE:-0}
+          wasm-pack test --chrome --chromedriver $CHROMEDRIVER_BIN --headless -- --all-features
 #  build-halo2-wasm-web:
 #    runs-on: ubuntu-latest
 #    needs: setup-halo2-wasm-env

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ graph.bin
 
 *.xcframework/
 node_modules
+
+mopro_flutter_bindings
+MoproAndroidBindings
+MoproiOSBindings
+build/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "allo-isolate"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449e356a4864c017286dbbec0e12767ea07efba29e3b7d984194c2a7ff3c4550"
+dependencies = [
+ "anyhow",
+ "atomic",
+ "backtrace",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +80,23 @@ checksum = "5f70d83b765fdc080dbcd4f4db70d8d23fe4761f2f02ebfa9146b833900634b4"
 dependencies = [
  "arrayvec",
  "bytes",
+]
+
+[[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -207,7 +235,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown",
+ "hashbrown 0.15.2",
  "itertools 0.13.0",
  "num-bigint",
  "num-integer",
@@ -371,7 +399,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown",
+ "hashbrown 0.15.2",
  "rayon",
 ]
 
@@ -504,6 +532,12 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
 name = "atomic-waker"
@@ -651,6 +685,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
+name = "build-target"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "832133bbabbbaa9fbdba793456a2827627a7d2b8fb96032fa1e7666d7895832b"
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +701,12 @@ name = "byte-slice-cast"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
+name = "bytemuck"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
 name = "byteorder"
@@ -1063,10 +1109,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "dart-sys"
+version = "4.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57967e4b200d767d091b961d6ab42cc7d0cc14fe9e052e75d0d3cf9eb732d895"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deflate64"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
+
+[[package]]
+name = "delegate-attr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51aac4c99b2e6775164b412ea33ae8441b2fde2dbf05a20bc0052a63d08c475b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "deranged"
@@ -1196,6 +1275,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,6 +1392,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "flutter_rust_bridge"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde126295b2acc5f0a712e265e91b6fdc0ed38767496483e592ae7134db83725"
+dependencies = [
+ "allo-isolate",
+ "android_logger",
+ "anyhow",
+ "build-target",
+ "bytemuck",
+ "byteorder",
+ "console_error_panic_hook",
+ "dart-sys",
+ "delegate-attr",
+ "flutter_rust_bridge_macros",
+ "futures",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "oslog",
+ "portable-atomic",
+ "threadpool",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "flutter_rust_bridge_macros"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f0420326b13675321b194928bb7830043b68cf8b810e1c651285c747abb080"
+dependencies = [
+ "hex",
+ "md-5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1485,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,10 +1516,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "futures-sink"
@@ -1393,8 +1561,10 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1560,6 +1730,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -1572,6 +1748,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1911,7 +2093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -2045,6 +2227,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,6 +2261,16 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2185,6 +2387,7 @@ dependencies = [
  "anyhow",
  "camino",
  "color-eyre",
+ "flutter_rust_bridge",
  "thiserror 2.0.12",
  "toml 0.8.22",
  "uniffi",
@@ -2324,6 +2527,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2395,6 +2608,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "oslog"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d2043d1f61d77cb2f4b1f7b7b2295f40507f5f8e9d1c8bf10a1ca5f97a3969"
+dependencies = [
+ "cc",
+ "dashmap",
+ "log",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,6 +2650,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2795,6 +3032,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3108,6 +3354,12 @@ checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll"
@@ -3473,6 +3725,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tests"
+version = "0.1.0"
+dependencies = [
+ "mopro-ffi",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3529,6 +3789,15 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,5 @@
 [workspace]
-members = [
-    "mopro-ffi",
-    "cli",
-    "mopro-wasm",
-    "circom-prover",
-]
+members = ["mopro-ffi", "cli", "mopro-wasm", "circom-prover", "tests"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 [dependencies]
 mopro-ffi = { path = "../mopro-ffi", features = [
     "build",
+    "uniffi",
 ], default-features = false }
 
 clap = { version = "4.0", features = ["derive"] }

--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -170,6 +170,28 @@ pub fn build_project(
                 let arch_refs: Vec<&String> = arch_strings.iter().collect();
                 build_from_str_arch::<AndroidPlatform>(mode, &current_dir, arch_refs, ())?;
             }
+            Platform::Flutter => {
+                let platform_str = selection.platform().as_str();
+                let mut command = std::process::Command::new("cargo");
+                command.args([
+                    "run",
+                    "--bin",
+                    platform_str,
+                    "--no-default-features",
+                    "--features",
+                    "flutter",
+                    "--release",
+                ]);
+
+                let status = command.status()?;
+
+                if !status.success() {
+                    return Err(anyhow::anyhow!(
+                        "Output with status code {}",
+                        status.code().unwrap()
+                    ));
+                }
+            }
             Platform::Web => {
                 let platform_str = selection.platform().as_str();
                 let mut command = std::process::Command::new("cargo");

--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -180,8 +180,10 @@ pub fn build_project(
                     "--no-default-features",
                     "--features",
                     "flutter",
-                    "--release",
                 ]);
+                if mode == Mode::Release {
+                    command.arg("--release");
+                }
 
                 let status = command.status()?;
 

--- a/cli/src/build/target_resolver.rs
+++ b/cli/src/build/target_resolver.rs
@@ -20,6 +20,7 @@ pub(super) struct PlatformSelection {
 pub(super) enum PlatformArchitectures {
     Ios(Vec<IosArch>),
     Android(Vec<AndroidArch>),
+    Flutter,
     Web,
 }
 
@@ -100,6 +101,7 @@ impl TargetSelection {
                 PlatformArchitectures::Android(archs) => {
                     archs.retain(|a| a.as_str() != arch);
                 }
+                PlatformArchitectures::Flutter => {}
                 PlatformArchitectures::Web => {}
             }
         }
@@ -107,6 +109,7 @@ impl TargetSelection {
             .retain(|selection| match &selection.architectures {
                 PlatformArchitectures::Ios(archs) => !archs.is_empty(),
                 PlatformArchitectures::Android(archs) => !archs.is_empty(),
+                PlatformArchitectures::Flutter => true,
                 PlatformArchitectures::Web => true,
             });
     }
@@ -148,6 +151,7 @@ impl PlatformArchitectures {
             PlatformArchitectures::Android(archs) => {
                 archs.iter().map(|arch| arch.as_str().to_string()).collect()
             }
+            PlatformArchitectures::Flutter => Vec::new(),
             PlatformArchitectures::Web => Vec::new(),
         }
     }
@@ -160,6 +164,7 @@ impl PlatformArchitectures {
             PlatformArchitectures::Android(archs) => {
                 archs.iter().any(|candidate| candidate.as_str() == arch)
             }
+            PlatformArchitectures::Flutter => false,
             PlatformArchitectures::Web => false,
         }
     }
@@ -232,6 +237,13 @@ fn resolve_architectures(
         selections.push(PlatformSelection {
             platform: Platform::Android,
             architectures: android_platform_arch,
+        });
+    }
+
+    if platforms.contains(&Platform::Flutter) {
+        selections.push(PlatformSelection {
+            platform: Platform::Flutter,
+            architectures: PlatformArchitectures::Flutter,
         });
     }
 

--- a/cli/src/constants.rs
+++ b/cli/src/constants.rs
@@ -1,4 +1,6 @@
-use mopro_ffi::app_config::constants::{ANDROID_BINDINGS_DIR, FLUTTER_BINDINGS_DIR, IOS_BINDINGS_DIR, WEB_BINDINGS_DIR};
+use mopro_ffi::app_config::constants::{
+    ANDROID_BINDINGS_DIR, FLUTTER_BINDINGS_DIR, IOS_BINDINGS_DIR, WEB_BINDINGS_DIR,
+};
 
 //
 // Platform Section

--- a/cli/src/constants.rs
+++ b/cli/src/constants.rs
@@ -1,4 +1,4 @@
-use mopro_ffi::app_config::constants::{ANDROID_BINDINGS_DIR, IOS_BINDINGS_DIR};
+use mopro_ffi::app_config::constants::{ANDROID_BINDINGS_DIR, FLUTTER_BINDINGS_DIR, IOS_BINDINGS_DIR, WEB_BINDINGS_DIR};
 
 //
 // Platform Section
@@ -7,6 +7,7 @@ use mopro_ffi::app_config::constants::{ANDROID_BINDINGS_DIR, IOS_BINDINGS_DIR};
 pub enum Platform {
     Ios,
     Android,
+    Flutter,
     Web,
 }
 
@@ -15,7 +16,7 @@ struct PlatformInfo {
     str: &'static str,
 }
 
-const PLATFORMS: [PlatformInfo; 3] = [
+const PLATFORMS: [PlatformInfo; 4] = [
     PlatformInfo {
         platform: Platform::Ios,
         str: "ios",
@@ -23,6 +24,10 @@ const PLATFORMS: [PlatformInfo; 3] = [
     PlatformInfo {
         platform: Platform::Android,
         str: "android",
+    },
+    PlatformInfo {
+        platform: Platform::Flutter,
+        str: "flutter",
     },
     PlatformInfo {
         platform: Platform::Web,
@@ -58,6 +63,7 @@ impl Platform {
         match self {
             Self::Ios => "iOS",
             Self::Android => "Android",
+            Self::Flutter => "Flutter",
             Self::Web => "WASM",
         }
     }
@@ -66,7 +72,8 @@ impl Platform {
         match self {
             Self::Ios => IOS_BINDINGS_DIR,
             Self::Android => ANDROID_BINDINGS_DIR,
-            Self::Web => "MoproWasmBindings",
+            Self::Flutter => FLUTTER_BINDINGS_DIR,
+            Self::Web => WEB_BINDINGS_DIR,
         }
     }
 }

--- a/cli/src/init/write_toml.rs
+++ b/cli/src/init/write_toml.rs
@@ -16,7 +16,7 @@ flutter = ["mopro-ffi/flutter"]
 
 [dependencies]
 mopro-wasm = { git = "https://github.com/zkmopro/mopro.git" }
-mopro-ffi = { git = "https://github.com/zkmopro/mopro.git", branch = "flutter-ffi } // TODO: change back to main
+mopro-ffi = { git = "https://github.com/zkmopro/mopro.git", branch = "flutter-ffi" } # TODO: change back to main
 thiserror = "2.0.12"
 anyhow = "1.0.99"
 
@@ -30,7 +30,7 @@ anyhow = "1.0.99"
 # NOIR_BUILD_DEPENDENCIES
 
 [dev-dependencies]
-mopro-ffi = { git = "https://github.com/zkmopro/mopro.git", features = ["uniffi-tests"] }
+mopro-ffi = { git = "https://github.com/zkmopro/mopro.git", branch = "flutter-ffi", features = ["uniffi-tests"] } # TODO: change back to main
 
 # CIRCOM_DEV_DEPENDENCIES
 # HALO2_DEV_DEPENDENCIES

--- a/cli/src/init/write_toml.rs
+++ b/cli/src/init/write_toml.rs
@@ -10,11 +10,13 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 # Adapters for different proof systems
 [features]
-default = []
+default = ["uniffi"]
+uniffi = ["mopro-ffi/uniffi"]
+flutter = ["mopro-ffi/flutter"]
 
 [dependencies]
 mopro-wasm = { git = "https://github.com/zkmopro/mopro.git" }
-mopro-ffi = { git = "https://github.com/zkmopro/mopro.git", features = ["uniffi"] }
+mopro-ffi = { git = "https://github.com/zkmopro/mopro.git", branch = "flutter-ffi } // TODO: change back to main
 thiserror = "2.0.12"
 anyhow = "1.0.99"
 

--- a/cli/src/template/circom/lib.rs
+++ b/cli/src/template/circom/lib.rs
@@ -3,11 +3,14 @@
 // Module containing the Circom circuit logic (Multiplier2)
 #[macro_use]
 mod circom;
+pub use circom::{generate_circom_proof, verify_circom_proof, CircomProofResult, ProofLib, G1, G2};
 
-rust_witness::witness!(multiplier2);
+mod witness {
+    rust_witness::witness!(multiplier2);
+}
 
-set_circom_circuits! {
-    ("multiplier2_final.zkey", circom_prover::witness::WitnessFn::RustWitness(multiplier2_witness)),
+crate::set_circom_circuits! {
+    ("multiplier2_final.zkey", circom_prover::witness::WitnessFn::RustWitness(witness::multiplier2_witness)),
 }
 
 #[cfg(test)]

--- a/cli/src/template/circom/lib.rs
+++ b/cli/src/template/circom/lib.rs
@@ -3,7 +3,9 @@
 // Module containing the Circom circuit logic (Multiplier2)
 #[macro_use]
 mod circom;
-pub use circom::{generate_circom_proof, verify_circom_proof, CircomProofResult, ProofLib, G1, G2};
+pub use circom::{
+    generate_circom_proof, verify_circom_proof, CircomProof, CircomProofResult, ProofLib, G1, G2,
+};
 
 mod witness {
     rust_witness::witness!(multiplier2);

--- a/cli/src/template/halo2/lib.rs
+++ b/cli/src/template/halo2/lib.rs
@@ -3,6 +3,7 @@
 // Module containing the Halo2 circuit logic (FibonacciMoproCircuit)
 #[macro_use]
 mod halo2;
+use halo2::{generate_halo2_proof, verify_halo2_proof, Halo2ProofResult};
 
 set_halo2_circuits! {
     ("plonk_fibonacci_pk.bin", plonk_fibonacci::prove, "plonk_fibonacci_vk.bin", plonk_fibonacci::verify),

--- a/cli/src/template/halo2/lib.rs
+++ b/cli/src/template/halo2/lib.rs
@@ -3,7 +3,7 @@
 // Module containing the Halo2 circuit logic (FibonacciMoproCircuit)
 #[macro_use]
 mod halo2;
-use halo2::{generate_halo2_proof, verify_halo2_proof, Halo2ProofResult};
+pub use halo2::{generate_halo2_proof, verify_halo2_proof, Halo2ProofResult};
 
 set_halo2_circuits! {
     ("plonk_fibonacci_pk.bin", plonk_fibonacci::prove, "plonk_fibonacci_vk.bin", plonk_fibonacci::verify),

--- a/cli/src/template/init/src/bin/flutter.rs
+++ b/cli/src/template/init/src/bin/flutter.rs
@@ -1,0 +1,5 @@
+fn main() {
+    // A simple wrapper around a build command provided by mopro.
+    // In the future this will likely be published in the mopro crate itself.
+    mopro_ffi::app_config::flutter::build();
+}

--- a/cli/src/template/init/src/circom.rs
+++ b/cli/src/template/init/src/circom.rs
@@ -15,27 +15,31 @@ use std::str::FromStr;
 //
 // Data structures for Circom proof representation
 //
-#[derive(Debug, Clone, uniffi::Record)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct CircomProofResult {
     pub proof: CircomProof,
     pub inputs: Vec<String>,
 }
 
-#[derive(Debug, Clone, Default, uniffi::Record)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct G1 {
     pub x: String,
     pub y: String,
     pub z: String,
 }
 
-#[derive(Debug, Clone, Default, uniffi::Record)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct G2 {
     pub x: Vec<String>,
     pub y: Vec<String>,
     pub z: Vec<String>,
 }
 
-#[derive(Debug, Clone, Default, uniffi::Record)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct CircomProof {
     pub a: G1,
     pub b: G2,
@@ -44,7 +48,8 @@ pub struct CircomProof {
     pub curve: String,
 }
 
-#[derive(Debug, Clone, Default, uniffi::Enum)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum ProofLib {
     #[default]
     Arkworks,
@@ -142,8 +147,8 @@ impl Into<CircomProverProofLib> for ProofLib {
 // Main functions for proof generation and verification
 //
 
-#[uniffi::export]
-pub(crate) fn generate_circom_proof(
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn generate_circom_proof(
     zkey_path: String,
     circuit_inputs: String,
     proof_lib: ProofLib,
@@ -177,8 +182,8 @@ pub(crate) fn generate_circom_proof(
     })
 }
 
-#[uniffi::export]
-pub(crate) fn verify_circom_proof(
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn verify_circom_proof(
     zkey_path: String,
     proof_result: CircomProofResult,
     proof_lib: ProofLib,
@@ -210,7 +215,7 @@ macro_rules! set_circom_circuits {
         ];
 
         #[inline]
-        pub fn circom_get(name: &str) -> Option<WitnessFn> {
+        pub(crate) fn circom_get(name: &str) -> Option<WitnessFn> {
             CIRCOM_CIRCUITS.iter()
                 .find(|(k, _)| *k == name)
                 .map(|(_, v)| *v)

--- a/cli/src/template/init/src/error.rs
+++ b/cli/src/template/init/src/error.rs
@@ -1,0 +1,10 @@
+#[derive(Debug, thiserror::Error)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Error))]
+pub enum MoproError {
+    #[error("CircomError: {0}")]
+    CircomError(String),
+    #[error("Halo2Error: {0}")]
+    Halo2Error(String),
+    #[error("NoirError: {0}")]
+    NoirError(String),
+}

--- a/cli/src/template/init/src/halo2.rs
+++ b/cli/src/template/init/src/halo2.rs
@@ -9,14 +9,15 @@ pub type Halo2ProveFn =
 
 pub type Halo2VerifyFn = fn(&str, &str, Vec<u8>, Vec<u8>) -> Result<bool, Box<dyn Error>>;
 
-#[derive(Debug, Clone, uniffi::Record)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct Halo2ProofResult {
     pub proof: Vec<u8>,
     pub inputs: Vec<u8>,
 }
 
-#[uniffi::export]
-pub(crate) fn generate_halo2_proof(
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn generate_halo2_proof(
     srs_path: String,
     pk_path: String,
     circuit_inputs: std::collections::HashMap<String, Vec<String>>,
@@ -32,8 +33,8 @@ pub(crate) fn generate_halo2_proof(
     Ok(result.into())
 }
 
-#[uniffi::export]
-pub(crate) fn verify_halo2_proof(
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn verify_halo2_proof(
     srs_path: String,
     vk_path: String,
     proof: Vec<u8>,

--- a/cli/src/template/init/src/lib.rs
+++ b/cli/src/template/init/src/lib.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 mod stubs;
 
-#[macro_use]
 mod error;
 pub use error::MoproError;
 
@@ -11,7 +10,7 @@ mopro_ffi::app!();
 /// You can also customize the bindings by #[uniffi::export]
 /// Reference: https://mozilla.github.io/uniffi-rs/latest/proc_macro/index.html
 #[cfg_attr(feature = "uniffi", uniffi::export)]
-fn mopro_hello_world() -> String {
+pub fn mopro_hello_world() -> String {
     "Hello, World!".to_string()
 }
 

--- a/cli/src/template/init/src/lib.rs
+++ b/cli/src/template/init/src/lib.rs
@@ -1,26 +1,31 @@
+#[macro_use]
+mod stubs;
+
+#[macro_use]
+mod error;
+pub use error::MoproError;
+
 // Initializes the shared UniFFI scaffolding and defines the `MoproError` enum.
 mopro_ffi::app!();
 
 /// You can also customize the bindings by #[uniffi::export]
 /// Reference: https://mozilla.github.io/uniffi-rs/latest/proc_macro/index.html
-#[uniffi::export]
-fn mopro_uniffi_hello_world() -> String {
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+fn mopro_hello_world() -> String {
     "Hello, World!".to_string()
 }
 
-#[macro_use]
-mod stubs;
+#[cfg(test)]
+mod uniffi_tests {
+    #[test]
+    fn test_mopro_hello_world() {
+        assert_eq!(super::mopro_hello_world(), "Hello, World!");
+    }
+}
+
 
 // CIRCOM_TEMPLATE
 
 // HALO2_TEMPLATE
 
 // NOIR_TEMPLATE
-
-#[cfg(test)]
-mod uniffi_tests {
-    #[test]
-    fn test_mopro_uniffi_hello_world() {
-        assert_eq!(super::mopro_uniffi_hello_world(), "Hello, World!");
-    }
-}

--- a/cli/src/template/init/src/noir.rs
+++ b/cli/src/template/init/src/noir.rs
@@ -19,8 +19,8 @@ use crate::MoproError;
 ///
 /// - `on_chain = true`: Uses Keccak hash for Solidity verifier compatibility
 /// - `on_chain = false`: Uses Poseidon hash for better performance
-#[uniffi::export]
-pub(crate) fn generate_noir_proof(
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn generate_noir_proof(
     circuit_path: String,
     srs_path: Option<String>,
     inputs: Vec<String>,
@@ -44,8 +44,8 @@ pub(crate) fn generate_noir_proof(
 ///
 /// - `on_chain = true`: Verifies Keccak-based proof (Solidity compatible)
 /// - `on_chain = false`: Verifies Poseidon-based proof (performance optimized)
-#[uniffi::export]
-pub(crate) fn verify_noir_proof(
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn verify_noir_proof(
     circuit_path: String,
     proof: Vec<u8>,
     on_chain: bool,
@@ -77,8 +77,8 @@ pub(crate) fn verify_noir_proof(
 ///
 /// - `on_chain = true`: Uses Keccak hash for Solidity verifier compatibility
 /// - `on_chain = false`: Uses Poseidon hash fotr better performance
-#[uniffi::export]
-pub(crate) fn get_noir_verification_key(
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn get_noir_verification_key(
     circuit_path: String,
     srs_path: Option<String>,
     on_chain: bool,

--- a/cli/src/template/init/src/stubs.rs
+++ b/cli/src/template/init/src/stubs.rs
@@ -2,29 +2,29 @@
 macro_rules! circom_stub {
     () => {
         mod circom_stub {
-            use crate::MoproError;
+            use crate::error::MoproError;
 
-            #[cfg_attr(feature = "uniffi", uniffi::Record)]
+            #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
             pub struct CircomProofResult {
                 pub proof: CircomProof,
                 pub inputs: Vec<String>,
             }
 
-            #[cfg_attr(feature = "uniffi", uniffi::Record)]
+            #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
             pub struct G1 {
                 pub x: String,
                 pub y: String,
                 pub z: String,
             }
 
-            #[cfg_attr(feature = "uniffi", uniffi::Record)]
+            #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
             pub struct G2 {
                 pub x: Vec<String>,
                 pub y: Vec<String>,
                 pub z: Vec<String>,
             }
 
-            #[cfg_attr(feature = "uniffi", uniffi::Record)]
+            #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
             pub struct CircomProof {
                 pub a: G1,
                 pub b: G2,
@@ -33,7 +33,7 @@ macro_rules! circom_stub {
                 pub curve: String,
             }
 
-            #[cfg_attr(feature = "uniffi", uniffi::Enum)]
+            #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
             pub enum ProofLib {
                 Arkworks,
                 Rapidsnark,

--- a/cli/src/template/init/src/stubs.rs
+++ b/cli/src/template/init/src/stubs.rs
@@ -4,27 +4,27 @@ macro_rules! circom_stub {
         mod circom_stub {
             use crate::MoproError;
 
-            #[derive(uniffi::Record)]
+            #[cfg_attr(feature = "uniffi", uniffi::Record)]
             pub struct CircomProofResult {
                 pub proof: CircomProof,
                 pub inputs: Vec<String>,
             }
 
-            #[derive(uniffi::Record)]
+            #[cfg_attr(feature = "uniffi", uniffi::Record)]
             pub struct G1 {
                 pub x: String,
                 pub y: String,
                 pub z: String,
             }
 
-            #[derive(uniffi::Record)]
+            #[cfg_attr(feature = "uniffi", uniffi::Record)]
             pub struct G2 {
                 pub x: Vec<String>,
                 pub y: Vec<String>,
                 pub z: Vec<String>,
             }
 
-            #[derive(uniffi::Record)]
+            #[cfg_attr(feature = "uniffi", uniffi::Record)]
             pub struct CircomProof {
                 pub a: G1,
                 pub b: G2,
@@ -33,14 +33,14 @@ macro_rules! circom_stub {
                 pub curve: String,
             }
 
-            #[derive(uniffi::Enum)]
+            #[cfg_attr(feature = "uniffi", uniffi::Enum)]
             pub enum ProofLib {
                 Arkworks,
                 Rapidsnark,
             }
 
-            #[uniffi::export]
-            pub(crate) fn generate_circom_proof(
+            #[cfg_attr(feature = "uniffi", uniffi::export)]
+            pub fn generate_circom_proof(
                 _zkey_path: String,
                 _circuit_inputs: String,
                 _proof_lib: ProofLib,
@@ -48,8 +48,8 @@ macro_rules! circom_stub {
                 panic!("Circom is not enabled in this build. Please select \"circom\" adapter when initializing the project.");
             }
 
-            #[uniffi::export]
-            pub(crate) fn verify_circom_proof(
+            #[cfg_attr(feature = "uniffi", uniffi::export)]
+            pub fn verify_circom_proof(
                 _zkey_path: String,
                 _proof_result: CircomProofResult,
                 _proof_lib: ProofLib,
@@ -57,6 +57,10 @@ macro_rules! circom_stub {
                 panic!("Circom is not enabled in this build. Please select \"circom\" adapter when initializing the project.");
             }
         }
+        pub use circom_stub::{
+            generate_circom_proof, verify_circom_proof, CircomProof, CircomProofResult, ProofLib,
+            G1, G2,
+        };
     };
 }
 
@@ -64,16 +68,17 @@ macro_rules! circom_stub {
 macro_rules! halo2_stub {
     () => {
         mod halo2_stub {
-            use crate::MoproError;
+            use crate::error::MoproError;
 
-            #[derive(uniffi::Record)]
+            #[derive(Debug, Clone, Default)]
+            #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
             pub struct Halo2ProofResult {
                 pub proof: Vec<u8>,
                 pub inputs: Vec<u8>,
             }
 
-            #[uniffi::export]
-            pub(crate) fn generate_halo2_proof(
+            #[cfg_attr(feature = "uniffi", uniffi::export)]
+            pub fn generate_halo2_proof(
                 _srs_path: String,
                 _pk_path: String,
                 _circuit_inputs: std::collections::HashMap<String, Vec<String>>,
@@ -81,8 +86,8 @@ macro_rules! halo2_stub {
                 panic!("Halo2 is not enabled in this build. Please select \"halo2\" adapter when initializing the project.");
             }
 
-            #[uniffi::export]
-            pub(crate) fn verify_halo2_proof(
+            #[cfg_attr(feature = "uniffi", uniffi::export)]
+            pub fn verify_halo2_proof(
                 _srs_path: String,
                 _vk_path: String,
                 _proof: Vec<u8>,
@@ -91,6 +96,7 @@ macro_rules! halo2_stub {
                 panic!("Halo2 is not enabled in this build. Please select \"halo2\" adapter when initializing the project.");
             }
         }
+        pub use halo2_stub::{generate_halo2_proof, verify_halo2_proof, Halo2ProofResult};
     };
 }
 
@@ -98,10 +104,10 @@ macro_rules! halo2_stub {
 macro_rules! noir_stub {
     () => {
         mod noir_stub {
-            use crate::MoproError;
+            use crate::error::MoproError;
 
-            #[uniffi::export]
-            pub(crate) fn generate_noir_proof(
+            #[cfg_attr(feature = "uniffi", uniffi::export)]
+            pub fn generate_noir_proof(
                 _circuit_path: String,
                 _srs_path: Option<String>,
                 _inputs: Vec<String>,
@@ -112,8 +118,8 @@ macro_rules! noir_stub {
                 panic!("Noir is not enabled in this build. Please select \"noir\" adapter when initializing the project.");
             }
 
-            #[uniffi::export]
-            pub(crate) fn verify_noir_proof(
+            #[cfg_attr(feature = "uniffi", uniffi::export)]
+            pub fn verify_noir_proof(
                 _circuit_path: String,
                 _proof: Vec<u8>,
                 _on_chain: bool,
@@ -125,8 +131,8 @@ macro_rules! noir_stub {
             }
 
 
-            #[uniffi::export]
-            pub(crate) fn get_noir_verification_key(
+            #[cfg_attr(feature = "uniffi", uniffi::export)]
+            pub fn get_noir_verification_key(
                 _circuit_path: String,
                 _srs_path: Option<String>,
                 _on_chain: bool,
@@ -138,5 +144,8 @@ macro_rules! noir_stub {
 
 
         }
+        pub use noir_stub::{
+            generate_noir_proof, get_noir_verification_key, verify_noir_proof,
+        };
     };
 }

--- a/cli/src/template/noir/lib.rs
+++ b/cli/src/template/noir/lib.rs
@@ -2,7 +2,7 @@
 
 // Module containing the Noir circuit logic (Multiplier2)
 mod noir;
-use noir::{generate_noir_proof, get_noir_verification_key, verify_noir_proof,};
+pub use noir::{generate_noir_proof, get_noir_verification_key, verify_noir_proof,};
 
 #[cfg(test)]
 mod noir_tests {

--- a/cli/src/template/noir/lib.rs
+++ b/cli/src/template/noir/lib.rs
@@ -2,6 +2,7 @@
 
 // Module containing the Noir circuit logic (Multiplier2)
 mod noir;
+use noir::{generate_noir_proof, get_noir_verification_key, verify_noir_proof,};
 
 #[cfg(test)]
 mod noir_tests {

--- a/mopro-ffi/Cargo.toml
+++ b/mopro-ffi/Cargo.toml
@@ -15,15 +15,21 @@ name = "mopro_ffi"
 [features]
 default = ["build"]
 
-uniffi = []
+uniffi = ["dep:uniffi"]
 uniffi-tests = ["uniffi", "uniffi/bindgen-tests"]
+
+flutter = ["toml", "flutter_rust_bridge"]
 
 build = ["toml", "uuid", "camino"]
 no_uniffi_exports = []
 
 [dependencies]
-uniffi = { workspace = true, features = ["bindgen"] }
+# UniFFI
+uniffi = { workspace = true, features = ["bindgen"], optional = true }
 toml = { version = "0.8.22", optional = true }
+
+# Flutter
+flutter_rust_bridge = { version = "=2.11.1", optional = true }
 
 # Error handling
 thiserror = "2.0.12"

--- a/mopro-ffi/src/app_config/flutter.rs
+++ b/mopro-ffi/src/app_config/flutter.rs
@@ -40,7 +40,7 @@ impl PlatformBuilder for FlutterPlatform {
         let cargo_toml_path = project_dir
             .join(FLUTTER_BINDINGS_DIR)
             .join("rust/Cargo.toml");
-        ensure_workspace_toml(&cargo_toml_path.to_string_lossy().to_string());
+        ensure_workspace_toml(cargo_toml_path.to_string_lossy().as_ref());
 
         // Import user defined crates
         let third_party_crate_name = raw_project_name_from_toml(project_dir)?;
@@ -49,7 +49,7 @@ impl PlatformBuilder for FlutterPlatform {
                 "add",
                 &third_party_crate_name,
                 "--path",
-                &project_dir.to_string_lossy().to_string(),
+                project_dir.to_string_lossy().as_ref(),
                 "--no-default-features",
                 "--features",
                 "flutter",
@@ -65,7 +65,7 @@ impl PlatformBuilder for FlutterPlatform {
         replace_relative_path_with_absolute(
             &cargo_toml_path,
             &third_party_crate_name,
-            &project_dir,
+            project_dir,
         )?;
 
         // Patch cargokit build script

--- a/mopro-ffi/src/app_config/flutter.rs
+++ b/mopro-ffi/src/app_config/flutter.rs
@@ -1,0 +1,316 @@
+use anyhow::Context;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use toml::Value;
+
+use crate::app_config::constants::{FlutterArch, FlutterPlatform, Mode, FLUTTER_BINDINGS_DIR};
+
+use super::raw_project_name_from_toml;
+use super::PlatformBuilder;
+
+// Maintained for backwards compatibility
+#[inline]
+pub fn build() {
+    if cfg!(feature = "uniffi") {
+        panic!("\"uniffi\" and \"flutter\" features cannot be enabled at the same time, please disable one of them in your Cargo.toml");
+    }
+    super::build_from_env::<FlutterPlatform>()
+}
+
+#[derive(Default)]
+pub struct FlutterBindingsParams {
+    pub using_noir: bool,
+}
+
+impl PlatformBuilder for FlutterPlatform {
+    type Arch = FlutterArch;
+    type Params = FlutterBindingsParams;
+
+    fn build(
+        _mode: Mode,
+        project_dir: &Path,
+        _target_archs: Vec<Self::Arch>,
+        _params: Self::Params,
+    ) -> anyhow::Result<PathBuf> {
+        // Init flutter bindings template
+        init_flutter_bindings(project_dir)?;
+
+        // Init workspace for bindings template
+        let cargo_toml_path = project_dir
+            .join(FLUTTER_BINDINGS_DIR)
+            .join("rust/Cargo.toml");
+        ensure_workspace_toml(&cargo_toml_path.to_string_lossy().to_string());
+
+        // Import user defined crates
+        let third_party_crate_name = raw_project_name_from_toml(project_dir)?;
+        let cargo_add_status = Command::new("cargo")
+            .args([
+                "add",
+                &third_party_crate_name,
+                "--path",
+                &project_dir.to_string_lossy().to_string(),
+                "--no-default-features",
+                "--features",
+                "flutter",
+            ])
+            .current_dir(project_dir.join(FLUTTER_BINDINGS_DIR).join("rust"))
+            .status()
+            .expect("failed to run cargo add");
+        if !cargo_add_status.success() {
+            return Err(anyhow::anyhow!("Failed to add third party crate"));
+        }
+
+        // Replace relative path with absolute path
+        replace_relative_path_with_absolute(
+            &cargo_toml_path,
+            &third_party_crate_name,
+            &project_dir,
+        )?;
+
+        // Patch cargokit build script
+        // See: https://github.com/fzyzcjy/flutter_rust_bridge/issues/2839
+        // TODO: remove this once the issue is fixed
+        patch_cargokit_build_script(project_dir)?;
+
+        // add C++ flag
+        add_cpp_flag_to_ios_podspec(project_dir)?;
+
+        // Disable android architecture support
+        disable_android_architecture_support(project_dir)?;
+
+        // Copy libc++_shared.so to jniLibs
+        copy_libcxx_shared_so_to_jni_libs(project_dir)?;
+
+        // Generate flutter bindings
+        let rust_root = project_dir.join(FLUTTER_BINDINGS_DIR).join("rust");
+        let dart_output = project_dir.join(FLUTTER_BINDINGS_DIR).join("lib/src/rust");
+        let generate_status = Command::new("flutter_rust_bridge_codegen")
+            .args(["generate"])
+            .args([
+                "--rust-root",
+                &rust_root.to_string_lossy(),
+                "--rust-input",
+                &third_party_crate_name,
+                "--dart-output",
+                &dart_output.to_string_lossy(),
+            ])
+            .current_dir(project_dir)
+            .status()
+            .expect("failed to run flutter_rust_bridge_codegen");
+        if !generate_status.success() {
+            return Err(anyhow::anyhow!("Failed to generate simple.rs"));
+        }
+
+        Ok(PathBuf::from(FLUTTER_BINDINGS_DIR))
+    }
+}
+
+fn install_flutter_rust_bridge_codegen() -> anyhow::Result<()> {
+    let output = Command::new("flutter_rust_bridge_codegen").output();
+    match output {
+        Ok(_) => {
+            // Command exists, no need to install
+            println!("flutter_rust_bridge_codegen already installed.");
+            return Ok(());
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Command not found, proceed with installation
+            println!("flutter_rust_bridge_codegen not found, installing...");
+            let status = Command::new("cargo")
+                .args(["install", "flutter_rust_bridge_codegen@=2.11.1"])
+                .status()
+                .expect("failed to run flutter_rust_bridge_codegen");
+            if !status.success() {
+                return Err(anyhow::anyhow!(
+                    "Failed to install flutter_rust_bridge_codegen"
+                ));
+            }
+        }
+        Err(e) => {
+            // Other error, propagate it
+            return Err(anyhow::anyhow!(
+                "Failed to check for flutter_rust_bridge_codegen: {}",
+                e
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn init_flutter_bindings(project_dir: &Path) -> anyhow::Result<()> {
+    let flutter_bindings_dir = project_dir.join(FLUTTER_BINDINGS_DIR);
+
+    install_flutter_rust_bridge_codegen()?;
+
+    if !flutter_bindings_dir.exists() {
+        let status = Command::new("flutter_rust_bridge_codegen")
+            .args(["create", FLUTTER_BINDINGS_DIR, "--template", "plugin"])
+            .status()
+            .expect("failed to run flutter_rust_bridge_codegen");
+
+        if !status.success() {
+            return Err(anyhow::anyhow!("flutter_rust_bridge_codegen failed"));
+        }
+    }
+
+    Ok(())
+}
+
+fn ensure_workspace_toml(cargo_toml_path: &str) {
+    let content = fs::read_to_string(cargo_toml_path).expect("Failed to read Cargo.toml");
+
+    if !content.contains("[workspace]") {
+        let new_content = format!("{content}\n\n[workspace]\n");
+        fs::write(cargo_toml_path, new_content).expect("Failed to write updated Cargo.toml");
+    }
+}
+
+fn replace_relative_path_with_absolute(
+    cargo_toml_path: &Path,
+    crate_name: &str,
+    abs_path: &Path,
+) -> anyhow::Result<()> {
+    let cargo_toml_content =
+        fs::read_to_string(cargo_toml_path).context("Failed to read Cargo.toml")?;
+    let mut cargo_toml: Value = cargo_toml_content
+        .parse::<Value>()
+        .context("Failed to parse Cargo.toml")?;
+
+    // If the `name` under [lib] section is set, using the `name` as library name.
+    // Otherwise, using the package name.
+    let crate_path = cargo_toml
+        .get_mut("dependencies")
+        .and_then(|pkg| pkg.get_mut(crate_name));
+
+    if let Some(Value::Table(table)) = crate_path {
+        table.insert(
+            "path".to_string(),
+            Value::String(abs_path.to_string_lossy().to_string()),
+        );
+    }
+
+    let updated_cargo_toml_content =
+        toml::to_string_pretty(&cargo_toml).context("Failed to serialize updated Cargo.toml")?;
+
+    fs::write(cargo_toml_path, updated_cargo_toml_content)
+        .context("Failed to write updated Cargo.toml")?;
+
+    Ok(())
+}
+
+fn patch_cargokit_build_script(project_dir: &Path) -> anyhow::Result<()> {
+    let cargo_kit_build_script_path = project_dir
+        .join(FLUTTER_BINDINGS_DIR)
+        .join("cargokit")
+        .join("gradle")
+        .join("plugin.gradle");
+    let cargo_kit_build_script_content = fs::read_to_string(cargo_kit_build_script_path.clone())
+        .context("Failed to read plugin.gradle")?;
+    if !cargo_kit_build_script_content.contains("if (plugin.class.name == \"com.flutter.gradle.FlutterPlugin\" || plugin.class.name == \"FlutterPlugin\")") {
+        let updated_content = cargo_kit_build_script_content.replace(
+        "if (plugin.class.name == \"com.flutter.gradle.FlutterPlugin\")",
+        "if (plugin.class.name == \"com.flutter.gradle.FlutterPlugin\" || plugin.class.name == \"FlutterPlugin\")"
+        );
+
+        let updated_content = updated_content.replace(
+            "        def platforms = com.flutter.gradle.FlutterPluginUtils.getTargetPlatforms(project).collect()",
+        "        def List<String> platforms\n            try {\n                platforms = com.flutter.gradle.FlutterPluginUtils.getTargetPlatforms(project).collect()\n            } catch (Exception ignored) {\n                platforms = plugin.getTargetPlatforms().collect()\n            }"
+        );
+
+        fs::write(&cargo_kit_build_script_path, updated_content)
+        .context("Failed to write updated plugin.gradle")?;
+    }
+
+    Ok(())
+}
+
+fn add_cpp_flag_to_ios_podspec(project_dir: &Path) -> anyhow::Result<()> {
+    let ios_podspec_path = project_dir
+        .join(FLUTTER_BINDINGS_DIR)
+        .join("ios")
+        .join(format!("{FLUTTER_BINDINGS_DIR}.podspec"));
+    let ios_podspec_content = fs::read_to_string(ios_podspec_path.clone()).context(format!(
+        "Failed to read {}",
+        ios_podspec_path.to_string_lossy()
+    ))?;
+    if !ios_podspec_content.contains("-lc++") {
+        let updated_content = ios_podspec_content.replace(
+        "'OTHER_LDFLAGS' => '-force_load ${BUILT_PRODUCTS_DIR}/libmopro_flutter_bindings.a'",
+        "'OTHER_LDFLAGS' => '-force_load ${BUILT_PRODUCTS_DIR}/libmopro_flutter_bindings.a -lc++'",
+        );
+        fs::write(&ios_podspec_path, updated_content).context(format!(
+            "Failed to write updated {FLUTTER_BINDINGS_DIR}.podspec"
+        ))?;
+    }
+
+    Ok(())
+}
+
+fn disable_android_architecture_support(project_dir: &Path) -> anyhow::Result<()> {
+    let android_gradle_path = project_dir
+        .join(FLUTTER_BINDINGS_DIR)
+        .join("cargokit")
+        .join("gradle")
+        .join("plugin.gradle");
+    let cargo_kit_build_script_content =
+        fs::read_to_string(android_gradle_path.clone()).context("Failed to read plugin.gradle")?;
+    let updated_content =
+        cargo_kit_build_script_content.replace("        platforms.add(\"android-x86\")", "");
+    let updated_content = updated_content.replace("        platforms.add(\"android-x64\")", "");
+    fs::write(&android_gradle_path, updated_content).context(format!(
+        "Failed to write updated {}",
+        android_gradle_path.to_string_lossy()
+    ))?;
+    Ok(())
+}
+
+fn copy_libcxx_shared_so_to_jni_libs(project_dir: &Path) -> anyhow::Result<()> {
+    let android_gradle_path = project_dir
+        .join(FLUTTER_BINDINGS_DIR)
+        .join("cargokit")
+        .join("gradle")
+        .join("plugin.gradle");
+    let cargo_kit_build_script_content =
+        fs::read_to_string(android_gradle_path.clone()).context("Failed to read plugin.gradle")?;
+
+    if !cargo_kit_build_script_content.contains("// After cargo build in CargoKitBuildTask.build()")
+    {
+        let updated_content = cargo_kit_build_script_content.replace(
+        "project.tasks.whenTaskAdded onTask",
+        "project.tasks.whenTaskAdded onTask\n
+                // After cargo build in CargoKitBuildTask.build()
+                def outputDir = new File(cargoOutputDir) // should be build/jniLibs/<buildType>
+
+                // Source path in your NDK sysroot
+                def ndkDir = plugin.project.android.ndkDirectory
+
+                // Map Gradle ABI -> NDK triple dir
+                def abiMap = [
+                    \"arm64-v8a\" : \"aarch64-linux-android\",
+                    \"armeabi-v7a\" : \"arm-linux-androideabi\",
+                    \"x86\"        : \"i686-linux-android\",
+                    \"x86_64\"     : \"x86_64-linux-android\"
+                ]
+
+                abiMap.each { abi, triple ->
+                    def srcLibcxx = new File(\"${ndkDir}/toolchains/llvm/prebuilt/${Os.isFamily(Os.FAMILY_MAC) ? \"darwin-x86_64\" : \"linux-x86_64\"}/sysroot/usr/lib/${triple}/libc++_shared.so\")
+                    def destDir = new File(\"${outputDir}/${abi}\")
+                    destDir.mkdirs()
+                    def destLibcxx = new File(destDir, \"libc++_shared.so\")
+
+                    project.copy {
+                        from srcLibcxx
+                        into destDir
+                    }
+                }"
+        );
+        fs::write(&android_gradle_path, updated_content).context(format!(
+            "Failed to write updated {}",
+            android_gradle_path.to_string_lossy()
+        ))?;
+    }
+
+    Ok(())
+}

--- a/mopro-ffi/src/app_config/ios.rs
+++ b/mopro-ffi/src/app_config/ios.rs
@@ -133,7 +133,8 @@ impl PlatformBuilder for IosPlatform {
             bindings_out.join(out_swift_file_name),
         )
         .context(format!(
-            "Failed to rename bindings from {gen_swift_file_name}"
+            "Failed to rename bindings from {}/{gen_swift_file_name}",
+            swift_bindings_dir.display(),
         ))?;
 
         let mut xcbuild_cmd = Command::new("xcodebuild");

--- a/mopro-ffi/src/lib.rs
+++ b/mopro-ffi/src/lib.rs
@@ -20,6 +20,7 @@ macro_rules! uniffi_setup {
     () => {
         // `::uniffi` must be available in the caller’s extern-prelude.
         extern crate mopro_ffi as uniffi;
+        uniffi::setup_scaffolding!();
     };
 }
 
@@ -29,6 +30,28 @@ macro_rules! uniffi_setup {
     () => {
         // No-op when `uniffi` feature isn't enabled in `mopro_ffi`.
     };
+}
+
+#[cfg(feature = "flutter")]
+pub use flutter_rust_bridge::*;
+
+#[cfg(feature = "flutter")]
+#[macro_export]
+macro_rules! flutter_setup {
+    () => {
+        // ::uniffi must be available in the caller’s extern-prelude.
+        extern crate mopro_ffi as flutter_rust_bridge;
+        pub fn init_app() {
+            // Default utilities - feel free to customize
+            flutter_rust_bridge::setup_default_user_utils();
+        }
+    };
+}
+
+#[cfg(not(feature = "flutter"))]
+#[macro_export]
+macro_rules! flutter_setup {
+    () => {};
 }
 
 /// This macro is used to setup the Mopro FFI library
@@ -91,7 +114,7 @@ macro_rules! uniffi_setup {
 macro_rules! app {
     () => {
         mopro_ffi::uniffi_setup!();
-        uniffi::setup_scaffolding!();
+        mopro_ffi::flutter_setup!();
 
         // This should be declared into this macro due to Uniffi's limitation
         // Please refer this issue: https://github.com/mozilla/uniffi-rs/issues/2257

--- a/mopro-ffi/src/lib.rs
+++ b/mopro-ffi/src/lib.rs
@@ -115,17 +115,5 @@ macro_rules! app {
     () => {
         mopro_ffi::uniffi_setup!();
         mopro_ffi::flutter_setup!();
-
-        // This should be declared into this macro due to Uniffi's limitation
-        // Please refer this issue: https://github.com/mozilla/uniffi-rs/issues/2257
-        #[derive(Debug, thiserror::Error, uniffi::Error)]
-        pub enum MoproError {
-            #[error("CircomError: {0}")]
-            CircomError(String),
-            #[error("Halo2Error: {0}")]
-            Halo2Error(String),
-            #[error("NoirError: {0}")]
-            NoirError(String),
-        }
     };
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "tests"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "ios"
+path = "bin/ios.rs"
+
+[[bin]]
+name = "android"
+path = "bin/android.rs"
+
+
+[[bin]]
+name = "flutter"
+path = "bin/flutter.rs"
+
+[lib]
+crate-type = ["lib", "cdylib", "staticlib"]
+
+[features]
+default = ["uniffi"]
+uniffi = ["mopro-ffi/uniffi"]
+flutter = ["mopro-ffi/flutter"]
+
+[dependencies]
+mopro-ffi = { path = "../mopro-ffi"}
+thiserror = "2.0.12"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tests"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [[bin]]
 name = "ios"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,27 @@
+# Test for Mopro FFI
+
+Run tests for different FFI bindings before building the CLI.
+
+## UniFFI
+
+### iOS
+```sh
+cargo run --bin ios
+```
+
+### Android
+
+```sh
+cargo run --bin android
+```
+
+## Flutter FFI
+
+> [!IMPORTANT]  
+> The `flutter` feature cannot be enbaled with `uniffi` feature together
+
+### Dart
+
+```sh
+cargo run --bin flutter --no-default-features --features flutter
+```

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,7 +18,7 @@ cargo run --bin android
 ## Flutter FFI
 
 > [!IMPORTANT]  
-> The `flutter` feature cannot be enbaled with `uniffi` feature together
+> The `flutter` feature cannot be enabled with `uniffi` feature together
 
 ### Dart
 

--- a/tests/bin/android.rs
+++ b/tests/bin/android.rs
@@ -1,0 +1,3 @@
+fn main() {
+    mopro_ffi::app_config::android::build();
+}

--- a/tests/bin/flutter.rs
+++ b/tests/bin/flutter.rs
@@ -1,0 +1,3 @@
+fn main() {
+    mopro_ffi::app_config::flutter::build();
+}

--- a/tests/bin/ios.rs
+++ b/tests/bin/ios.rs
@@ -1,0 +1,3 @@
+fn main() {
+    mopro_ffi::app_config::ios::build();
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -15,4 +15,3 @@ fn mopro_uniffi_hello_world() -> String {
 pub fn mopro_flutter_hello_world() -> String {
     mopro_hello_world()
 }
-

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -16,12 +16,3 @@ pub fn mopro_flutter_hello_world() -> String {
     mopro_hello_world()
 }
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn addition_works() {
-        #[cfg(feature = "uniffi")]
-        mopro_ffi::app_config::ios::build();
-        assert!(true);
-    }
-}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,0 +1,27 @@
+#[cfg(feature = "uniffi")]
+mopro_ffi::app!();
+
+fn mopro_hello_world() -> String {
+    "Hello, World!".to_string()
+}
+
+#[cfg(feature = "uniffi")]
+#[uniffi::export]
+fn mopro_uniffi_hello_world() -> String {
+    mopro_hello_world()
+}
+
+#[cfg(feature = "flutter")]
+pub fn mopro_flutter_hello_world() -> String {
+    mopro_hello_world()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn addition_works() {
+        #[cfg(feature = "uniffi")]
+        mopro_ffi::app_config::ios::build();
+        assert!(true);
+    }
+}


### PR DESCRIPTION
- Added Flutter architecture support and bindings generation.
- Updated .gitignore to include Flutter-related directories.
- Enhanced Cargo.toml files to include new dependencies and features for Flutter.
- Introduced tests for Flutter and Android bindings.
- Refactored app_config to accommodate Flutter-specific configurations.

## 
- import from https://github.com/vivianjeng/mopro-refactor

## Usage

- build (optional)
   ```sh
   mopro build
   ```
   and choose `flutter`
- create
   ```sh
   mopro create
   ```
   and choose `flutter`
- run the app
   ```sh
   cd flutter && flutter pub get && flutter run
   ```
- update bindings
   add functions in `lib.rs` and expose to the public e.g.
   ```rust
   pub fn flutter_rust_bridge_function() -> String {
      "flutter_rust_bridge".to_string()
   }
   ```
   then run
   ```sh
   mopro build
   ```
   (`mopro update` is not required since the flutter app takes the `mopro_flutter_bindings` from the path it is generated)
   Then it can be used in `flutter/lib/main.dart`
   ```dart
   await flutterRustBridgeFunction()
   ```

## Note
- It utilizes https://github.com/fzyzcjy/flutter_rust_bridge with some fixes
   - fix Android error: https://github.com/fzyzcjy/flutter_rust_bridge/issues/2839
   - add `libc++_share.o` in Android
   - add `-lc++` in iOS
   - patch package name
- It doesn't require to choose architecture because the it uses [cargokit](https://github.com/irondash/cargokit) to detect the architecture by flutter
- The rust crate is written in **absolute path** in `mopro_flutter_bindings/rust/Cargo.toml`. It doesn't matter if the folder changes the path. However, it cannot be used while copy to other device.
- The flutter app takes the `mopro_flutter_bindings` in the `mopro-example-app` root folder. It doesn't copy to `flutter` folder.
- some functions with `*mut std::ffi::c_void` and exposed to the public will throw errors
   e.g. `rust-witness` and `uniffi`
   ```sh
   thread 'main' panicked at /Users/zhengyawen/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/flutter_rust_bridge_codegen-2.11.1/src/library/codegen/parser/mir/parser/lifetime_replacer.rs:8:43:
   called `Result::unwrap()` on an `Err` value: Error("expected `const` or `mut`")
   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
   ```
   you can use 
   ```sh
   cargo expand --lib --no-default-features
   ``` 
   to check
   the solution for `rust-witness` to make it only visible in a module, e.g.
   ```diff
   + mod witness {
      rust_witness::witness!(multiplier2);
   + }
   ```
   ```diff
   + witness::multiplier2_witness
   - multiplier2_witness
   ```