### PR TITLE
Serialize Circom proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,6 +842,7 @@ dependencies = [
  "rayon",
  "rust-rapidsnark",
  "rust-witness",
+ "serde",
  "serde_json",
  "uuid",
  "witnesscalc-adapter",
@@ -2468,6 +2469,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]

--- a/circom-prover/Cargo.toml
+++ b/circom-prover/Cargo.toml
@@ -56,12 +56,14 @@ num = { version = "0.4.0" }
 num-traits = { version = "0.2.15", default-features = false }
 num-bigint = { version = "0.4.3", default-features = false, features = [
     "rand",
+    "serde",
 ] }
 anyhow = "1.0.95"
 rust-witness = { workspace = true, optional = true }
 byteorder = { version = "1.0.0" }
 uuid = { version = "1.9.1", features = ["v4"] }
 serde_json = "1.0.94"
+serde = { version = "1.0", features = ["derive"] }
 
 # arkworks
 ark-ec = { version = "=0.5.0", default-features = false, features = [

--- a/circom-prover/src/prover.rs
+++ b/circom-prover/src/prover.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use circom::Proof;
 use num::BigUint;
+use serde::{Deserialize, Serialize};
 use std::{str::FromStr, thread::JoinHandle};
 
 pub mod ark_circom;
@@ -11,13 +12,52 @@ pub mod arkworks;
 #[cfg(feature = "rapidsnark")]
 pub mod rapidsnark;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PublicInputs(pub Vec<BigUint>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CircomProof {
     pub proof: Proof,
     pub pub_inputs: PublicInputs,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prover::circom::{Proof, G1, G2};
+    use num::BigUint;
+
+    #[test]
+    fn serde_roundtrip_circom_proof() {
+        let a = G1 {
+            x: BigUint::from(1u32),
+            y: BigUint::from(2u32),
+            z: BigUint::from(1u32),
+        };
+        let b = G2 {
+            x: [BigUint::from(3u32), BigUint::from(4u32)],
+            y: [BigUint::from(5u32), BigUint::from(6u32)],
+            z: [BigUint::from(1u32), BigUint::from(0u32)],
+        };
+        let c = G1 {
+            x: BigUint::from(7u32),
+            y: BigUint::from(8u32),
+            z: BigUint::from(1u32),
+        };
+        let proof = Proof {
+            a,
+            b,
+            c,
+            protocol: "groth16".to_string(),
+            curve: "bn128".to_string(),
+        };
+        let pub_inputs = PublicInputs(vec![BigUint::from(9u32), BigUint::from(10u32)]);
+        let cp = CircomProof { proof, pub_inputs };
+
+        let serialized = serde_json::to_string(&cp).unwrap();
+        let deserialized: CircomProof = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(cp, deserialized);
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/circom-prover/src/prover/circom.rs
+++ b/circom-prover/src/prover/circom.rs
@@ -15,6 +15,7 @@ use ark_ff::{BigInteger, PrimeField};
 use ark_serialize::CanonicalDeserialize;
 use num::BigUint;
 use num_traits::Zero;
+use serde::{Deserialize, Serialize};
 
 pub const PROTOCOL_GROTH16: &str = "groth16";
 pub const CURVE_BN254: &str = "bn128";
@@ -57,7 +58,7 @@ impl From<Inputs> for Vec<bls12_381_Fr> {
 }
 
 // Follow the interface: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/snarkjs/index.d.cts
-#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct G1 {
     pub x: BigUint,
     pub y: BigUint,
@@ -112,7 +113,7 @@ impl G1 {
     }
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct G2 {
     pub x: [BigUint; 2],
     pub y: [BigUint; 2],
@@ -184,7 +185,7 @@ impl G2 {
     }
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Proof {
     pub a: G1,
     pub b: G2,


### PR DESCRIPTION
This pull request adds serialization and deserialization support for proof data structures in the Circom prover. Additionally, a unit test is introduced to ensure correct round-trip serialization for the `CircomProof` struct.

See [this](https://github.com/privacy-ethereum/csp-benchmarks/issues/84) for motivation behind the changes.