### PR TITLE
docs: add guidance on avoiding `*const ::std::ffi::c_void` in Flutter…

### DIFF
--- a/docs/docs/setup/flutter-setup.md
+++ b/docs/docs/setup/flutter-setup.md
@@ -201,6 +201,50 @@ Don't forget to modify the input values for your specific case!
     -   Make the function `pub` in `src/lib.rs` to expose it (See the [Rust setup](rust-setup.md#-customize-the-bindings) guide for details).<br/>
         Once exported, the function will be available across all supported platforms.
 
+## ⚠️ Avoid using the `*const ::std::ffi::c_void` type in `lib.rs`
+
+When running Flutter Rust Bridge, this type can cause build errors like:
+
+```sh
+Running Xcode build...
+Xcode build done.                                            3.1s
+Failed to build iOS app
+Error (Xcode): failed to run custom build command for
+`mopro-example-app v0.1.0
+(/Users/...)`
+/Users/.../flutter/ios/Pods/SEVERE:0:0
+```
+
+To identify problematic functions, run:
+
+```sh
+cargo expand --lib
+```
+
+and check for any functions that use `*const ::std::ffi::c_void` as input or output types.
+
+For example, when using `rust_witness::witness!(...)`,
+it may expose public functions that include the `*const ::std::ffi::c_void type`.
+
+To avoid this, wrap the macro inside a private module and expose your own safe public functions instead:
+
+```rust title="src/lib.rs"
+mod witness {
+    rust_witness::witness!(...);
+}
+
+// Expose a safe public function instead of directly using raw pointers
+pub fn generate_circom_proof(
+    zkey_path: String,
+    circuit_inputs: String,
+    proof_lib: ProofLib,
+) -> Result<CircomProofResult, MoproError> {
+    // ...
+}
+```
+
+This approach keeps the FFI layer internal and prevents `*const ::std::ffi::c_void` types from appearing in your public API.
+
 ## ⚠️ Error when running `flutter run --release`
 
 If you see an error like this:


### PR DESCRIPTION
… Rust Bridge

- Introduced a section in the Flutter setup documentation to warn against using the `*const ::std::ffi::c_void` type in `lib.rs`, which can lead to build errors.
- Provided instructions for identifying problematic functions and suggested wrapping macros in private modules to maintain a safe public API.