### PR TITLE
fix: remove redundant to_vec() clone in verify()

### DIFF
--- a/circom-prover/src/prover/arkworks.rs
+++ b/circom-prover/src/prover/arkworks.rs
@@ -114,8 +114,7 @@ fn verify<T: Pairing + FieldSerialization>(
         .iter()
         .map(|v| T::ScalarField::from(v.clone()))
         .collect::<Vec<_>>();
-    let public_inputs_fr = serialized_inputs.to_vec();
     let verified =
-        Groth16::<T, CircomReduction>::verify_with_processed_vk(&pvk, &public_inputs_fr, &proof)?;
+        Groth16::<T, CircomReduction>::verify_with_processed_vk(&pvk, &serialized_inputs, &proof)?;
     Ok(verified)
 }


### PR DESCRIPTION
This change eliminates an unnecessary to_vec() clone in verify()
We already collect public inputs into a Vec<T::ScalarField> and immediately cloned it into another Vec only to pass it as a slice to Groth16::verify_with_processed_vk.
Since the verifier accepts a slice, we can borrow the original vector (&serialized_inputs) directly.
This removes an extra allocation and copy per call, without altering behavior or API expectations.
Lifetimes remain valid because the borrowed vector lives through the verification call.