### PR TITLE
refactor(app_config): remove dead Params for Flutter and React Native

### DIFF
--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -5,7 +5,6 @@ use include_dir::include_dir;
 use include_dir::Dir;
 use mopro_ffi::app_config::constants::ReactNativePlatform;
 use mopro_ffi::app_config::constants::{AndroidArch, AndroidPlatform, Arch, IosPlatform, Mode};
-use mopro_ffi::app_config::react_native::ReactNativeBindingsParams;
 use std::env;
 
 use mopro_ffi::app_config::build_from_str_arch;
@@ -199,14 +198,7 @@ pub fn build_project(
             Platform::ReactNative => {
                 let arch_strings = selection.architecture_strings();
                 let arch_refs: Vec<&String> = arch_strings.iter().collect();
-                build_from_str_arch::<ReactNativePlatform>(
-                    mode,
-                    &current_dir,
-                    arch_refs,
-                    ReactNativeBindingsParams {
-                        using_noir: config.adapter_contains(Adapter::Noir),
-                    },
-                )?;
+                build_from_str_arch::<ReactNativePlatform>(mode, &current_dir, arch_refs, ())?;
             }
             Platform::Web => {
                 let platform_str = selection.platform().as_str();

--- a/mopro-ffi/src/app_config/flutter.rs
+++ b/mopro-ffi/src/app_config/flutter.rs
@@ -18,14 +18,9 @@ pub fn build() {
     super::build_from_env::<FlutterPlatform>()
 }
 
-#[derive(Default)]
-pub struct FlutterBindingsParams {
-    pub using_noir: bool,
-}
-
 impl PlatformBuilder for FlutterPlatform {
     type Arch = FlutterArch;
-    type Params = FlutterBindingsParams;
+    type Params = ();
 
     fn build(
         _mode: Mode,

--- a/mopro-ffi/src/app_config/react_native.rs
+++ b/mopro-ffi/src/app_config/react_native.rs
@@ -15,14 +15,9 @@ pub fn build() {
     super::build_from_env::<ReactNativePlatform>()
 }
 
-#[derive(Default)]
-pub struct ReactNativeBindingsParams {
-    pub using_noir: bool,
-}
-
 impl PlatformBuilder for ReactNativePlatform {
     type Arch = ReactNativeArch;
-    type Params = ReactNativeBindingsParams;
+    type Params = ();
 
     fn build(
         mode: Mode,


### PR DESCRIPTION
Removes unused Params structs from flutter.rs and react_native.rs by switching PlatformBuilder::Params to unit (). The React Native CLI call is adjusted to pass (). This eliminates dead code and clarifies the API. iOS Params remain intact since using_noir is used to set IPHONEOS_DEPLOYMENT_TARGET.