### PR TITLE
perf: remove extra zkey_path clone

### DIFF
--- a/circom-prover/src/lib.rs
+++ b/circom-prover/src/lib.rs
@@ -33,7 +33,7 @@ impl CircomProver {
         zkey_path: String,
     ) -> Result<CircomProof> {
         let wit_thread = witness::generate_witness(wit_fn, json_input_str);
-        prover::prove(proof_lib, zkey_path.clone(), wit_thread)
+        prover::prove(proof_lib, zkey_path, wit_thread)
     }
 
     pub fn verify(proof_lib: ProofLib, proof: CircomProof, zkey_path: String) -> Result<bool> {


### PR DESCRIPTION
CircomProver::prove already takes ownership of zkey_path and only forwards it to prover::prove, so cloning the string inside the method did not provide any benefit. This change passes zkey_path directly to prover::prove, removing an unnecessary allocation while keeping the public API untouched.