### PR TITLE
feat: include xcframework in package.json for React Native bindings

### DIFF
--- a/mopro-ffi/src/app_config/react_native.rs
+++ b/mopro-ffi/src/app_config/react_native.rs
@@ -148,6 +148,16 @@ fn generate_react_native_bindings(
         build_for_arch(platform, mode, &android_target_string, &bindings_dir)?;
     }
 
+    // Include the xcframework in the package.json for mopro-react-native-package
+    let npm_status = Command::new("npm")
+        .args(["pkg", "set", "files[]=*.xcframework/**"])
+        .current_dir(bindings_dir)
+        .status()
+        .expect("failed to set files in package.json");
+    if !npm_status.success() {
+        return Err(anyhow::anyhow!("Failed to set files in package.json"));
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
- Added functionality to set the xcframework files in the package.json of the mopro-react-native-package during the binding generation process.
- Enhanced error handling to ensure successful execution of the npm command for setting files.

These changes improve the packaging process for React Native bindings, ensuring that necessary files are included for proper functionality.