### PR TITLE
docs: update Circom, Halo2, and Noir adapter documentation for clarit…

### DIFF
--- a/docs/docs/adapters/circom.md
+++ b/docs/docs/adapters/circom.md
@@ -15,8 +15,9 @@ Use Circom to compile your `.circom` file into `.wasm` and `.r1cs` files:
 ```sh
 circom <your_circuit>.circom --wasm --r1cs -o <output_dir>
 ```
-- `<your_circuit>.circom`: your circuit source file
-- `<output_dir>`: directory for output files (e.g., `test-vectors/circom/`)
+
+-   `<your_circuit>.circom`: your circuit source file
+-   `<output_dir>`: directory for output files (e.g., `test-vectors/circom/`)
 
 ### 2. Trusted Setup (Powers of Tau)
 
@@ -59,20 +60,17 @@ See the [circom-prover README](https://github.com/zkmopro/mopro/blob/main/circom
 
 ## Samples
 
-Explore how the Circom adapter is implemented by checking out the [test-e2e](https://github.com/zkmopro/mopro/tree/main/test-e2e) where we maintain (and test) each adapter.
+Please follow the mopro CLI [getting started](/docs/getting-started) and select the **Circom** adapter to see how to implement a Circom prover using mopro.
 
 ## Setup the rust project
 
 You can follow the instructions in the [Rust Setup](/setup/rust-setup.md) guide to create a new Rust project that builds this library with Circom proofs.
 
-In your `Cargo.toml` file, ensure the `circom` feature is activated for `mopro-ffi`:
+In your `Cargo.toml` file, ensure the `circom-prover` package is imported:
 
 ```toml
-[features]
-default = ["mopro-ffi/circom"]
-
 [dependencies]
-mopro-ffi = { version = "0.2" }
+circom-prover = "0.1"
 # ...
 ```
 
@@ -94,7 +92,7 @@ type RustWitnessWtnsFn = fn(HashMap<String, Vec<BigInt>>) -> Vec<BigInt>;
 
 -   Implementing the Witness Function
 
-For simplicity, you can use the `witness!` macro provided by the `rust-witness` crate. This macro generates a witness function for you given the circuit name. You can read more about the `witness!` macro [here](https://github.com/vimwitch/rust-witness).
+For simplicity, you can use the `witness!` macro provided by the `rust-witness` crate. This macro generates a witness function for you given the circuit name. You can read more about the `witness!` macro [here](https://github.com/chancehudson/rust-witness).
 
 -   Adding the `rust-witness` Crate Dependency
 
@@ -151,7 +149,7 @@ rust_witness::witness!(multiplier3);
 rust_witness::witness!(keccak256256test);
 ```
 
-This will generate the witness function for the specified circuit following [the naming convention here](https://github.com/vimwitch/rust-witness?tab=readme-ov-file#rust-witness).
+This will generate the witness function for the specified circuit following [the naming convention here](https://github.com/chancehudson/rust-witness?tab=readme-ov-file#rust-witness).
 
 ### [`witnesscalc_adapter`](https://github.com/zkmopro/witnesscalc_adapter)
 
@@ -178,7 +176,7 @@ To use it, you must first add the `witnesscalc-adapter` crate to your `Cargo.tom
 ```toml
 [dependencies]
 # ...
-mopro-ffi = { version="0.2", features = ["witnesscalc"] } # activate witnesscalc feature
+circom-prover = { version="0.1", features = ["witnesscalc"] } # activate witnesscalc feature
 witnesscalc-adapter = "0.1"
 
 [build-dependencies]
@@ -238,7 +236,7 @@ To use it, you only need to activate the `circom-witnesscalc` feature in `mopro-
 ```toml
 [dependencies]
 # ...
-mopro-ffi = { version= "0.2", features = ["circom-witnesscalc"] } # activate circom-witnesscalc feature
+circom-prover = { version= "0.1", features = ["circom-witnesscalc"] } # activate circom-witnesscalc feature
 ```
 
 -   Use the Mopro helper to enable the graph functionality in your project.
@@ -308,11 +306,11 @@ Mopro now supports 2 Circom provers. You can find more information in [the blog 
 ```toml
 [dependencies]
 # ...
-mopro-ffi = { version= "0.2", features = ["rapidsnark"] } # activate rapidsnark feature
+circom-prover = { version= "0.1", features = ["rapidsnark"] } # activate rapidsnark feature
 
 [build-dependencies]
 # ...
-mopro-ffi = { version= "0.2", features = ["rapidsnark"] } # activate rapidsnark featurer
+circom-prover = { version= "0.1", features = ["rapidsnark"] } # activate rapidsnark featurer
 ```
 
 ## Generate Proofs

--- a/docs/docs/adapters/noir.md
+++ b/docs/docs/adapters/noir.md
@@ -10,16 +10,18 @@ You can explore real examples of how the Noir adapter works in these projects:
 -   [stealthnote-mobile](https://github.com/vivianjeng/stealthnote-mobile)
 -   [mopro-wallet-connect-noir](https://github.com/moven0831/mopro-wallet-connect-noir)
 
+Or follow the mopro CLI [getting started](/docs/getting-started) and select the **Noir** adapter to see how to implement a Noir prover using mopro.
+
 ## Setting Up the Rust Project
 
-To get started, follow the [Rust Setup Guide](/setup/rust-setup.md) and activate the `noir` feature in your `Cargo.toml`:
+To get started, follow the [Rust Setup Guide](/setup/rust-setup.md) and ensure the `noir_rs` package is imported:
 
 ```toml
-[features]
-default = ["mopro-ffi/noir"]
-
 [dependencies]
-mopro-ffi = { version = "0.2" }
+noir_rs = { package = "noir", git = "https://github.com/zkmopro/noir-rs", features = [
+    "barretenberg",
+    "android-compat",
+], branch = "v1.0.0-beta.8-3" }
 # ...
 ```
 
@@ -35,16 +37,16 @@ The Noir adapter depends on [`zkmopro/noir-rs`](https://github.com/zkmopro/noir-
 
 The Noir adapter supports two functions as oracle hash options for different use cases:
 
-- **Poseidon hash**: Default choice, optimized for performance and off-chain verification
-- **Keccak256 hash**: Gas-efficient, required for Solidity verifier compatibility and on-chain verification
+-   **Poseidon hash**: Default choice, optimized for performance and off-chain verification
+-   **Keccak256 hash**: Gas-efficient, required for Solidity verifier compatibility and on-chain verification
 
 The hash function is automatically selected based on the `on_chain` parameter.
 
 ### Key Features
 
-- **Automatic Hash Selection**: Automatically chooses between Poseidon (performance) and Keccak256 (EVM compatibility) based on your use case
-- **Memory Optimization**: Low memory mode available for mobile devices
-- **Cross-Platform**: Works across iOS, Android, and other supported platforms
+-   **Automatic Hash Selection**: Automatically chooses between Poseidon (performance) and Keccak256 (EVM compatibility) based on your use case
+-   **Memory Optimization**: Low memory mode available for mobile devices
+-   **Cross-Platform**: Works across iOS, Android, and other supported platforms
 
 ## Proving and Verifying Functions
 
@@ -84,19 +86,19 @@ pub fn get_noir_verification_key(
 
 ### Parameters
 
-- `circuit_path`: Path to the compiled Noir `.json` circuit
-- `srs_path`: Optional path to the structured reference string
-- `inputs`: List of strings representing public/private inputs (proof generation only)
-- `proof`: The serialized proof to verify (verification only)
-- `on_chain`: If `true`, uses Keccak256 hash for Solidity compatibility; if `false`, uses Poseidon hash for better performance
-- `vk`: Pre-generated verification key bytes
-- `low_memory_mode`: Enables memory optimization for resource-constrained environments
+-   `circuit_path`: Path to the compiled Noir `.json` circuit
+-   `srs_path`: Optional path to the structured reference string
+-   `inputs`: List of strings representing public/private inputs (proof generation only)
+-   `proof`: The serialized proof to verify (verification only)
+-   `on_chain`: If `true`, uses Keccak256 hash for Solidity compatibility; if `false`, uses Poseidon hash for better performance
+-   `vk`: Pre-generated verification key bytes
+-   `low_memory_mode`: Enables memory optimization for resource-constrained environments
 
 ### Usage Notes
 
-- **Hash Selection**: Set `on_chain = true` for Ethereum/EVM compatibility, or `on_chain = false` for better performance
-- **Verification Keys**: Pre-generate verification keys using `get_noir_verification_key` and reuse them for better performance
-- **Memory Optimization**: Enable `low_memory_mode = true` for resource-constrained mobile environments
+-   **Hash Selection**: Set `on_chain = true` for Ethereum/EVM compatibility, or `on_chain = false` for better performance
+-   **Verification Keys**: Pre-generate verification keys using `get_noir_verification_key` and reuse them for better performance
+-   **Memory Optimization**: Enable `low_memory_mode = true` for resource-constrained mobile environments
 
 ## Platform Support
 
@@ -114,3 +116,70 @@ The Noir adapter supports the following target platforms with Barretenberg backe
 | Linux Desktop           | `x86_64-unknown-linux-gnu` | ✅     |
 
 All platforms use pre-compiled Barretenberg binaries automatically downloaded from [zkmopro/aztec-packages releases](https://github.com/zkmopro/aztec-packages/releases) during the build process.
+
+## Using the Library
+
+After you have specified the circuits you want to use, you can follow the usual steps to build the library and use it in your project.
+
+### iOS API
+
+The Noir adapter exposes the following functions to be used in the iOS project:
+
+### `generateNoirProof`
+
+```swift
+public func generateNoirProof(circuitPath: String, srsPath: String?, inputs: [String], onChain: Bool, vk: Data, lowMemoryMode: Bool)throws  -> Data 
+```
+
+### `verifyNoirProof`
+
+```swift
+public func verifyNoirProof(circuitPath: String, proof: Data, onChain: Bool, vk: Data, lowMemoryMode: Bool)throws  -> Bool  
+```
+
+### `getNoirVerificationKey`
+
+```swift
+public func getNoirVerificationKey(circuitPath: String, srsPath: String?, onChain: Bool, lowMemoryMode: Bool)throws  -> Data  {
+
+```
+
+### Android API
+
+The Noir adapter exposes the equivalent functions and types to be used in the Android project.
+
+### `generateNoirProof`
+
+```kotlin
+fun `generateNoirProof`(
+    `circuitPath`: kotlin.String,
+    `srsPath`: kotlin.String?,
+    `inputs`: List<kotlin.String>,
+    `onChain`: kotlin.Boolean,
+    `vk`: kotlin.ByteArray,
+    `lowMemoryMode`: kotlin.Boolean,
+): kotlin.ByteArray
+```
+
+### `verifyNoirProof`
+
+```kotlin
+fun `verifyNoirProof`(
+    `circuitPath`: kotlin.String,
+    `proof`: kotlin.ByteArray,
+    `onChain`: kotlin.Boolean,
+    `vk`: kotlin.ByteArray,
+    `lowMemoryMode`: kotlin.Boolean,
+): kotlin.Boolean
+```
+
+### `getNoirVerificationKey`
+
+```kotlin
+fun `getNoirVerificationKey`(
+    `circuitPath`: kotlin.String,
+    `srsPath`: kotlin.String?,
+    `onChain`: kotlin.Boolean,
+    `lowMemoryMode`: kotlin.Boolean,
+): kotlin.ByteArray
+```


### PR DESCRIPTION
…y and accuracy

- Enhanced the Circom adapter documentation by improving formatting and updating references to the correct `circom-prover` package.
- Revised the Halo2 adapter documentation to clarify setup instructions and correct links to example projects.
- Updated the Noir adapter documentation to reflect changes in package imports and added new sections for iOS and Android APIs.

These updates improve the overall clarity and usability of the documentation for users implementing these adapters.