### PR TITLE
feat: add useSharedLibrary option for Android in ubnr.config.yaml

### DIFF
--- a/mopro-ffi/src/app_config/template/react_native/ubrn.config.yaml
+++ b/mopro-ffi/src/app_config/template/react_native/ubrn.config.yaml
@@ -4,3 +4,4 @@ rust:
 
 android:
     apiLevel: 28
+    useSharedLibrary: true


### PR DESCRIPTION
- Introduced the `useSharedLibrary` option in the Android configuration of `ubrn.config.yaml` to enhance library management for React Native applications.
- This addition allows for better integration and sharing of libraries within the Android environment.