### PR TITLE
feat: add output directory and offline flag support in project initia…

### DIFF
--- a/cli/src/bindgen.rs
+++ b/cli/src/bindgen.rs
@@ -125,6 +125,7 @@ pub fn bindgen(
     init_project(
         &Some(proving_adapter.as_str().to_string()),
         &Some(project_name.to_string()),
+        &None,
         true,
     )?;
 
@@ -187,7 +188,8 @@ pub fn bindgen(
         )?;
     }
     // Run the build command
-    build_project(arg_mode, arg_platforms, arg_architectures, None, true)?;
+    let offline = false; //TODO: get offline flag from command line
+    build_project(arg_mode, arg_platforms, arg_architectures, None, offline, true)?;
 
     // Copy the bindings folder to the output directory
     fs::create_dir_all(&output_base_dir)?;

--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -29,6 +29,7 @@ pub fn build_project(
     arg_platforms: &Option<Vec<String>>,
     arg_architectures: &Option<Vec<String>>,
     auto_update_flag: Option<bool>,
+    offline: bool,
     quiet: bool,
 ) -> Result<()> {
     // Detect `Cargo.toml` file before starting build process
@@ -82,6 +83,7 @@ pub fn build_project(
                     &None,
                     &None,
                     auto_update_flag,
+                    offline,
                     quiet,
                 );
             }
@@ -100,6 +102,7 @@ pub fn build_project(
                     &None,
                     &None,
                     auto_update_flag,
+                    offline,
                     quiet,
                 );
             }
@@ -130,6 +133,7 @@ pub fn build_project(
                         &None,
                         &None,
                         auto_update_flag,
+                        offline,
                         quiet,
                     );
                 }
@@ -148,6 +152,7 @@ pub fn build_project(
                     mode,
                     &current_dir,
                     arch_refs,
+                    offline,
                     IosBindingsParams {
                         using_noir: config.adapter_contains(Adapter::Noir),
                     },
@@ -156,7 +161,7 @@ pub fn build_project(
             Platform::Android => {
                 let arch_strings = selection.architecture_strings();
                 let arch_refs: Vec<&String> = arch_strings.iter().collect();
-                build_from_str_arch::<AndroidPlatform>(mode, &current_dir, arch_refs, ())?;
+                build_from_str_arch::<AndroidPlatform>(mode, &current_dir, arch_refs, offline, ())?;
             }
             Platform::Flutter => {
                 let platform_str = selection.platform().as_str();
@@ -168,6 +173,11 @@ pub fn build_project(
                     "--no-default-features",
                     "--features",
                     "flutter",
+                    if offline {
+                        "--offline"
+                    } else {
+                        ""
+                    },
                 ]);
                 if mode == Mode::Release {
                     command.arg("--release");
@@ -185,13 +195,14 @@ pub fn build_project(
             Platform::ReactNative => {
                 let arch_strings = selection.architecture_strings();
                 let arch_refs: Vec<&String> = arch_strings.iter().collect();
-                build_from_str_arch::<ReactNativePlatform>(mode, &current_dir, arch_refs, ())?;
+                build_from_str_arch::<ReactNativePlatform>(mode, &current_dir, arch_refs, offline, ())?;
             }
             Platform::Web => {
                 build_from_str_arch::<WebPlatform>(
                     mode,
                     &current_dir,
                     vec![&"wasm32-unknown-unknown".to_string()],
+                    offline,
                     (),
                 )?;
             }

--- a/cli/src/create/utils.rs
+++ b/cli/src/create/utils.rs
@@ -170,6 +170,7 @@ pub fn check_bindings(project_dir: &Path, platform: Platform) -> Result<Option<P
             &Some(vec![platform.as_str().to_string()]),
             &None,
             Some(false),
+            false, //TODO: get offline flag from command line
             false,
         )?;
 

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -19,6 +19,7 @@ mod write_toml;
 pub fn init_project(
     arg_adapter: &Option<String>,
     arg_project_name: &Option<String>,
+    arg_output_dir: &Option<String>,
     quiet: bool,
 ) -> Result<()> {
     let project_name: String = match arg_project_name.as_deref() {
@@ -46,7 +47,16 @@ pub fn init_project(
     };
 
     let current_dir = env::current_dir()?;
-    let project_dir = current_dir.join(&project_name);
+    let project_dir = if let Some(output_dir) = arg_output_dir {
+        let path = Path::new(output_dir);
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            current_dir.join(path).to_path_buf()
+        }
+    } else {
+        current_dir.join(&project_name)
+    };
     fs::create_dir(&project_dir)?;
 
     // Change directory to the project directory

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -36,6 +36,8 @@ enum Commands {
         adapter: Option<String>,
         #[arg(long)]
         project_name: Option<String>,
+        #[arg(long, help = "Specify the output directory for the project.")]
+        output_dir: Option<String>,
         #[arg(long, help = "Show instruction message for init")]
         show: bool,
     },
@@ -60,6 +62,8 @@ enum Commands {
             conflicts_with = "auto_update"
         )]
         no_auto_update: bool,
+        #[arg(long)]
+        offline: bool,
         #[arg(long, help = "Show instruction message for build")]
         show: bool,
     },
@@ -159,13 +163,14 @@ fn main() {
         Commands::Init {
             adapter,
             project_name,
+            output_dir,
             show,
         } => {
             if *show {
-                print::print_init_instructions("<PROJECT NAME>".to_string());
+                print::print_init_instructions("<PROJECT_NAME>".to_string());
                 return;
             }
-            match init::init_project(adapter, project_name, false) {
+            match init::init_project(adapter, project_name, output_dir, false) {
                 Ok(_) => {}
                 Err(e) => style::print_red_bold(format!("Failed to initialize project: {e:?}")),
             }
@@ -176,6 +181,7 @@ fn main() {
             architectures,
             auto_update,
             no_auto_update,
+            offline,
             show,
         } => {
             if *show {
@@ -189,7 +195,7 @@ fn main() {
             } else {
                 None
             };
-            match build::build_project(mode, platforms, architectures, auto_update_flag, false) {
+            match build::build_project(mode, platforms, architectures, auto_update_flag, *offline, false) {
                 Ok(_) => {}
                 Err(e) => style::print_red_bold(format!("Failed to build project: {e:?}")),
             }
@@ -262,7 +268,7 @@ fn main() {
                 return;
             }
 
-            match init::init_project(adapter, project_name, false) {
+            match init::init_project(adapter, project_name, &None, false) {
                 Ok(_) => {}
                 Err(e) => style::print_red_bold(format!("Failed to initialize project: {e:?}")),
             }
@@ -273,7 +279,8 @@ fn main() {
             } else {
                 None
             };
-            match build::build_project(mode, platforms, architectures, auto_update_flag, false) {
+            let offline = false; //TODO: get offline flag from command line
+            match build::build_project(mode, platforms, architectures, auto_update_flag, offline, false) {
                 Ok(_) => {}
                 Err(e) => style::print_red_bold(format!("Failed to build project: {e:?}")),
             }

--- a/mopro-ffi/src/app_config/android.rs
+++ b/mopro-ffi/src/app_config/android.rs
@@ -35,6 +35,7 @@ impl PlatformBuilder for AndroidPlatform {
         mode: Mode,
         project_dir: &Path,
         target_archs: Vec<Self::Arch>,
+        offline: bool,
         _params: Self::Params,
     ) -> anyhow::Result<PathBuf> {
         let uniffi_style_identifier = project_name_from_toml(project_dir)
@@ -63,7 +64,7 @@ impl PlatformBuilder for AndroidPlatform {
         let mut latest_out_lib_path = PathBuf::new();
         for arch in target_archs {
             latest_out_lib_path =
-                build_for_arch(arch, &lib_name, &build_dir, &bindings_out, mode).context(
+                build_for_arch(arch, &lib_name, &build_dir, &bindings_out, offline, mode).context(
                     format!("Failed to build for architecture: {}", arch.as_str()),
                 )?;
         }
@@ -92,6 +93,7 @@ fn build_for_arch(
     lib_name: &str,
     build_dir: &Path,
     bindings_out: &Path,
+    offline: bool,
     mode: Mode,
 ) -> anyhow::Result<PathBuf> {
     let arch_str = arch.as_str();
@@ -108,6 +110,9 @@ fn build_for_arch(
         .arg("--lib");
     if mode == Mode::Release {
         build_cmd.arg("--release");
+    }
+    if offline {
+        build_cmd.arg("--offline");
     }
     build_cmd
         .env("CARGO_BUILD_TARGET_DIR", build_dir)

--- a/mopro-ffi/src/app_config/constants.rs
+++ b/mopro-ffi/src/app_config/constants.rs
@@ -479,6 +479,7 @@ pub trait PlatformBuilder: Platform {
         mode: Mode,
         project_dir: &std::path::Path,
         target_arch: Vec<Self::Arch>,
+        offline: bool,
         params: Self::Params,
     ) -> anyhow::Result<std::path::PathBuf>;
 }

--- a/mopro-ffi/src/app_config/flutter.rs
+++ b/mopro-ffi/src/app_config/flutter.rs
@@ -26,6 +26,7 @@ impl PlatformBuilder for FlutterPlatform {
         _mode: Mode,
         project_dir: &Path,
         _target_archs: Vec<Self::Arch>,
+        _offline: bool, // TODO: see if flutter_rust_bridge_codegen supports offline mode
         _params: Self::Params,
     ) -> anyhow::Result<PathBuf> {
         // Init flutter bindings template

--- a/mopro-ffi/src/app_config/ios.rs
+++ b/mopro-ffi/src/app_config/ios.rs
@@ -35,6 +35,7 @@ impl PlatformBuilder for IosPlatform {
         mode: Mode,
         project_dir: &Path,
         target_archs: Vec<Self::Arch>,
+        offline: bool,
         params: Self::Params,
     ) -> anyhow::Result<PathBuf> {
         let uniffi_style_identifier = project_name_from_toml(project_dir)
@@ -84,6 +85,9 @@ impl PlatformBuilder for IosPlatform {
                 // The dependencies of Noir libraries need iOS 15 and above.
                 if params.using_noir {
                     build_cmd.env("IPHONEOS_DEPLOYMENT_TARGET", "15.0");
+                }
+                if offline {
+                    build_cmd.arg("--offline");
                 }
                 build_cmd
                     .arg("--lib")

--- a/mopro-ffi/src/app_config/mod.rs
+++ b/mopro-ffi/src/app_config/mod.rs
@@ -60,6 +60,7 @@ fn build_from_env<Builder: PlatformBuilder>() {
     let mode = get_build_mode();
     let project_dir = get_project_dir();
     let target_archs: Vec<Builder::Arch> = get_target_archs();
+    let offline = false;
     let params = Builder::Params::default();
 
     // Do not build if no target architectures are specified
@@ -67,7 +68,7 @@ fn build_from_env<Builder: PlatformBuilder>() {
         return;
     }
 
-    Builder::build(mode, &project_dir, target_archs, params)
+    Builder::build(mode, &project_dir, target_archs, offline, params)
         .context(format!(
             "Failed to build {} bindings",
             Builder::identifier()
@@ -80,6 +81,7 @@ pub fn build_from_str_arch<Builder: PlatformBuilder>(
     mode: Mode,
     project_dir: &Path,
     target_archs: Vec<&String>,
+    offline: bool,
     params: Builder::Params,
 ) -> anyhow::Result<PathBuf> {
     if target_archs.is_empty() {
@@ -94,7 +96,7 @@ pub fn build_from_str_arch<Builder: PlatformBuilder>(
         .map(Builder::Arch::parse_from_str)
         .collect();
 
-    Builder::build(mode, project_dir, target_archs, params).context(format!(
+    Builder::build(mode, project_dir, target_archs, offline, params).context(format!(
         "Failed to build {} bindings",
         Builder::identifier()
     ))

--- a/mopro-ffi/src/app_config/react_native.rs
+++ b/mopro-ffi/src/app_config/react_native.rs
@@ -23,6 +23,7 @@ impl PlatformBuilder for ReactNativePlatform {
         mode: Mode,
         project_dir: &Path,
         target_archs: Vec<Self::Arch>,
+        _offline: bool, // TODO: see if uniffi-bindgen-react-native supports offline mode
         _params: Self::Params,
     ) -> anyhow::Result<PathBuf> {
         install_uniffi_bindgen_react_native()?;

--- a/mopro-ffi/src/app_config/web.rs
+++ b/mopro-ffi/src/app_config/web.rs
@@ -21,6 +21,7 @@ impl PlatformBuilder for WebPlatform {
         mode: Mode,
         project_dir: &Path,
         _target_archs: Vec<Self::Arch>,
+        _offline: bool, // TODO: see if wasm-pack supports offline mode
         _params: Self::Params,
     ) -> anyhow::Result<PathBuf> {
         let _wasm_style_identifier = project_name_from_toml(project_dir)

--- a/tests/Config.toml
+++ b/tests/Config.toml
@@ -1,0 +1,7 @@
+build_mode = "release"
+target_adapters = []
+target_platforms = ["ios"]
+ios = ["aarch64-apple-ios-sim"]
+auto_update = false
+
+[update]


### PR DESCRIPTION
…lization and build

- Enhanced the `init_project` function to accept an optional output directory, allowing users to specify where the project should be created.
- Updated the `build_project` function to include an offline flag, enabling builds to be executed without internet access.
- Adjusted command-line arguments in the main application to support the new output directory and offline options, improving user flexibility during project setup and builds.