### PR TITLE
docs: fix React Native SDK examples

### DIFF
--- a/docs/docs/sdk/react-native.md
+++ b/docs/docs/sdk/react-native.md
@@ -95,13 +95,13 @@ const circuitInputs = {
     b: [b],
 };
 
-const res: CircomProofResult = await generateCircomProof(
+const circomProofResult: CircomProofResult = await generateCircomProof(
     ZKEY_PATH,
     JSON.stringify(circuitInputs),
     ProofLib.Arkworks
 );
 
-const res: boolean = await verifyCircomProof(
+const isValid: boolean = await verifyCircomProof(
     ZKEY_PATH,
     circomProofResult,
     ProofLib.Arkworks

--- a/docs/versioned_docs/version-0.2/sdk/react-native.md
+++ b/docs/versioned_docs/version-0.2/sdk/react-native.md
@@ -86,7 +86,7 @@ const proofResult: CircomProofResult =
 
 const isValid: boolean = await MoproReactNativePackage.verifyProof(
     ZKEY_PATH,
-    parsedProofResult
+    proofResult
 );
 
 console.log("Proof verification result:", isValid);


### PR DESCRIPTION
Updates React Native SDK docs examples to use consistent variable names circomProofResult, isValid, proofResult across current and versioned docs