### PR TITLE
feat: add graph_prove function for witness calculation and correspond…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,14 +893,14 @@ dependencies = [
 [[package]]
 name = "circom-witnesscalc"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3fb734f91de7e7002678ea3238fddfd4ee7afd33e9ed975176f4a94794a55a"
+source = "git+https://github.com/iden3/circom-witnesscalc?branch=main#2e03ba73c3d47dd7af4d7741a4e4f79498f95ab7"
 dependencies = [
  "anyhow",
  "ark-bn254",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "bindgen",
+ "bitvec",
  "byteorder",
  "indicatif",
  "libc",

--- a/circom-prover/Cargo.toml
+++ b/circom-prover/Cargo.toml
@@ -93,7 +93,7 @@ rand = { version = "0.8", features = ["std"] }
 witnesscalc-adapter = { version = "0.1", optional = true }
 
 # circom-witnesscalc
-circom-witnesscalc = { version = "0.2.1", optional = true }
+circom-witnesscalc = { git = "https://github.com/iden3/circom-witnesscalc", branch = "main", optional = true }
 once_cell = { version = "1.21.3", optional = true }
 
 # rapidsnark

--- a/circom-prover/src/witness.rs
+++ b/circom-prover/src/witness.rs
@@ -11,7 +11,7 @@ use witnesscalc_adapter::parse_witness_to_bigints;
 type RustWitnessWtnsFn = fn(HashMap<String, Vec<BigInt>>) -> Vec<BigInt>;
 /// Witness function signature for witnesscalc_adapter (inputs) -> witness
 type WitnesscalcWtnsFn = fn(&str) -> anyhow::Result<Vec<u8>>;
-/// Witness function signature for circom-witnesscalc (inputs, graph_path) -> witness
+/// Witness function signature for circom-witnesscalc (inputs) -> witness
 type CircomWitnessCalcWtnsFn = fn(&str) -> anyhow::Result<Vec<u8>>;
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
…ing test

- Implemented the `graph_prove` function in `CircomProver` to calculate witnesses using a graph and JSON input.
- Added a test case for `graph_prove` to verify its functionality with Arkworks and a sample graph.
- Updated witness function signatures in `witness.rs` for clarity.