### PR TITLE
chore: remove redundant drops in circom qap reduction

### DIFF
--- a/circom-prover/src/prover/ark_circom/qap.rs
+++ b/circom-prover/src/prover/ark_circom/qap.rs
@@ -77,8 +77,6 @@ impl R1CSToQAP for CircomReduction {
         domain.fft_in_place(&mut b);
 
         let mut ab = domain.mul_polynomials_in_evaluation_domain(&a, &b);
-        drop(a);
-        drop(b);
 
         domain.ifft_in_place(&mut c);
         D::distribute_powers_and_mul_by_const(&mut c, root_of_unity, F::one());


### PR DESCRIPTION
<!-- в чем причина правок? тоесть понятным образом обьясняешь что не так было до наших правок -->
Previously the witness_map_from_matrices implementation explicitly called drop(a) and drop(b) right after mul_polynomials_in_evaluation_domain. These vectors were not used afterwards and would be naturally dropped at
the end of the function, so the explicit drops did not change semantics and only added noise to the code.

<!-- Четкое и лаконичное общее описание изменений, вносимых этим PR -->
This change removes the redundant explicit drops of the temporary vectors a and b in the CircomReduction QAP witness mapping, relying on Rust’s normal scope-based destruction to clean them up.