### PR TITLE
chore: bump mopro-ffi/cli to 0.3.6, pin template to fix Kotlin CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "mopro-cli"
-version = "0.3.4"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "mopro-ffi"
-version = "0.3.4"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "camino",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mopro-cli"
-version = "0.3.4"
+version = "0.3.6"
 edition = "2021"
 description = "A CLI tool for creating a mobile native app with Mopro FFI"
 license = "MIT OR Apache-2.0"

--- a/cli/src/init/write_toml.rs
+++ b/cli/src/init/write_toml.rs
@@ -16,7 +16,7 @@ flutter = ["mopro-ffi/flutter"]
 wasm = ["mopro-ffi/wasm"]
 
 [dependencies]
-mopro-ffi = { version = "0.3.4" }
+mopro-ffi = { version = "=0.3.6" }
 thiserror = "2.0.12"
 anyhow = "1.0.99"
 
@@ -32,7 +32,7 @@ anyhow = "1.0.99"
 # GNARK_BUILD_DEPENDENCIES
 
 [dev-dependencies]
-mopro-ffi = { version = "0.3.4", features = ["uniffi-tests"] }
+mopro-ffi = { version = "=0.3.6", features = ["uniffi-tests"] }
 
 # CIRCOM_DEV_DEPENDENCIES
 # HALO2_DEV_DEPENDENCIES
@@ -40,7 +40,7 @@ mopro-ffi = { version = "0.3.4", features = ["uniffi-tests"] }
 # GNARK_DEV_DEPENDENCIES
 
 [target.wasm32-unknown-unknown.dependencies]
-mopro-ffi = { version = "0.3.4", features = ["wasm"] }
+mopro-ffi = { version = "=0.3.6", features = ["wasm"] }
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.6"
 

--- a/mopro-ffi/Cargo.toml
+++ b/mopro-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mopro-ffi"
-version = "0.3.4"
+version = "0.3.6"
 edition = "2021"
 description = "Mopro is a toolkit for ZK app development on mobile. Mopro makes client-side proving on mobile simple."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bumps `mopro-ffi` and `mopro-cli` from `0.3.4` → `0.3.6` (skipping the poisoned `0.3.5` slot on crates.io).
- Pins the `mopro init` template (`cli/src/init/write_toml.rs`) to `mopro-ffi = "=0.3.6"` (exact-version pin) so a future bad release in the 0.3.x range cannot silently break the template again.

## Why

Every `cli_template_tests` matrix job on `main` has been red since 2026-03-16 with:

```
…/uniffi/mopro_example_*/mopro_example_*.kt:83:46: warning: redundant call of conversion method.
this.data?.getByteBuffer(0, this.len.toLong())?.also {
error: warnings found and -Werror specified
test uniffi_foreign_language_testcase_test_ffi_hello_world_kts ... FAILED
```

Root cause:

1. The workspace already pins `uniffi = "=0.31.0"` (PR #658). UniFFI 0.31 fixed the redundant `.toLong()` in `RustBufferTemplate.kt:50` (0.29 emits `this.len.toLong()`, 0.31 emits `this.len`).
2. The template generated by `mopro init` depends on `mopro-ffi = "0.3.4"` (`cli/src/init/write_toml.rs:19,35,43`). Cargo resolves that to the latest published `0.3.x` on crates.io, which is **`mopro-ffi 0.3.5`** — released on 2026-03-08 from the `origin/v0.3.5` branch (based on a pre-#658 main), still locked to `uniffi =0.29.0`. Verified via the crates.io dependency API.
3. UniFFI's `bindgen-tests` feature runs `kotlinc -Werror`. A recent GitHub Actions runner-image refresh bumped kotlinc to a release that flags the redundant `.toLong()` as a warning — which becomes a fatal error under `-Werror`.

Regression bisect confirms the break is environmental, not source: last green run was `ef60c27` (2026-03-03), first red run was `6e59bac` (2026-03-16), and the only intermediate commit on `main` is a docs-only blog post (#702).

`cli_build_android` (gradle) is unaffected; only the Kotlin UniFFI foreign-language test in `cli_template_tests` fails. The Swift sibling test (`…_test_ffi_hello_world_swift`) passes.

## Publishing (post-merge)

There's no release workflow in this repo; previous releases were manual. After merge:

```bash
git checkout main && git pull
cargo publish -p mopro-ffi
cargo publish -p mopro-cli
git tag v0.3.6 && git push --tags
```

Then verify on crates.io that `mopro-ffi 0.3.6` lists `uniffi 0.31.x` under Dependencies.

> ⚠️ Until `mopro-ffi 0.3.6` is on crates.io, this PR's own CI will fail to resolve the new `=0.3.6` pin in the template. The fix only goes green on `main` once the publish step above completes and CI is re-run there.

## Out of scope

`cli/src/bindgen.rs:166-167` still references a stale `mopro-ffi = { version = "0.3.2", features = ["uniffi"] }` literal that no longer matches what `write_toml.rs` emits — this silently breaks the witnesscalc-adapter path. Unrelated to the Kotlin CI failure; flagging here so it doesn't get lost.

## Test plan

- [ ] CI: `cli_template_tests` (5 adapters × 2 OSes) goes green on `main` after `mopro-ffi 0.3.6` is published.
- [ ] Manual: on a clean machine, `cargo install --path cli && mopro init testproj && cd testproj && cargo test --all --all-features` succeeds end-to-end.
- [ ] Crates.io: `curl -s https://crates.io/api/v1/crates/mopro-ffi/0.3.6/dependencies` shows `uniffi 0.31.x`, not `=0.29.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)