### PR TITLE
chore: pin mopro-ffi path-dep version in mopro-cli for publish

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "mopro"
 path = "src/main.rs"
 
 [dependencies]
-mopro-ffi = { path = "../mopro-ffi", features = [
+mopro-ffi = { path = "../mopro-ffi", version = "=0.3.6", features = [
     "build",
     "uniffi",
 ], default-features = false }


### PR DESCRIPTION
## Summary

Adds `version = "=0.3.6"` alongside the existing `path = "../mopro-ffi"` in `cli/Cargo.toml` for the `mopro-ffi` dependency.

## Why

Follow-up to #706. When trying to publish `mopro-cli 0.3.6` to crates.io, `cargo publish` rejects the manifest:

```
error: failed to verify manifest at `cli/Cargo.toml`
Caused by:
  all dependencies must have a version requirement specified when publishing.
  dependency `mopro-ffi` does not specify a version
```

For path dependencies, Cargo strips the `path =` on upload and substitutes the `version =` requirement — so a path dep without a version is publishable only inside the workspace, not to crates.io. Adding `version = "=0.3.6"` lets the published `mopro-cli 0.3.6` resolve against `mopro-ffi 0.3.6` on crates.io while in-workspace builds still resolve via path.

`=0.3.6` (exact pin) matches what #706 did for the `mopro init` template — the two crates are versioned in lockstep, and an exact pin prevents `mopro-cli 0.3.6` from accidentally resolving against a future `mopro-ffi 0.3.7` that hasn't been validated together.

## Next step

After this merges:

```bash
git checkout main && git pull
cargo publish -p mopro-cli
git tag v0.3.6 && git push --tags
```

## Test plan

- [ ] `cargo check --workspace` still passes (no behavior change inside workspace).
- [ ] `cargo publish -p mopro-cli --dry-run` succeeds on this branch.
- [ ] After merge + publish, `https://crates.io/crates/mopro-cli/0.3.6` exists and lists `mopro-ffi =0.3.6` as a dep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)