### PR TITLE
fix(wasm): bump wasm nightly to 2025-02-20, stop silent wasm-build failures

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -522,12 +522,16 @@ jobs:
                   CI: "true"
               run: |
                   set -euo pipefail
-                  rustup component add rust-src --toolchain nightly-2024-07-18
+                  rustup component add rust-src --toolchain nightly-2025-02-20
                   # TODO: allow mopro CLI to run fully non-interactive so we can drop the pseudo-tty workaround below
                   if [[ "$RUNNER_OS" == "macOS" ]]; then
                     printf 'y\n' | script -q /dev/null "$GITHUB_WORKSPACE/bin/mopro" build --mode release --platforms web
                   else
-                    printf 'y\n' | script -q -c "$GITHUB_WORKSPACE/bin/mopro build --mode release --platforms web" /dev/null
+                    printf 'y\n' | script -q -e -c "$GITHUB_WORKSPACE/bin/mopro build --mode release --platforms web" /dev/null
+                  fi
+                  if [ ! -d MoproWasmBindings ]; then
+                    echo "::error::wasm build did not produce MoproWasmBindings/"
+                    exit 1
                   fi
             - name: Create Web framework (release, halo2)
               working-directory: ${{ runner.temp }}/mopro-example-${{ matrix.adapter }}
@@ -554,7 +558,7 @@ jobs:
             - name: Setup Rust
               uses: ./.github/actions/setup-rust
               with:
-                  toolchain: nightly-2024-07-18
+                  toolchain: nightly-2025-02-20
                   cache-key: wasm-env
             - name: Cache wasm-pack
               id: cache-wasm-pack

--- a/mopro-ffi/rust-toolchain.toml
+++ b/mopro-ffi/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-07-18"
+channel = "nightly-2025-02-20"
 components = ["rust-src"]
 targets = ["wasm32-unknown-unknown"]

--- a/mopro-ffi/src/app_config/web.rs
+++ b/mopro-ffi/src/app_config/web.rs
@@ -44,7 +44,7 @@ impl PlatformBuilder for WebPlatform {
         let mut cmd = Command::new("rustup");
         cmd.args([
             "run",
-            "nightly-2024-07-18",
+            "nightly-2025-02-20",
             "wasm-pack",
             "build",
             "--target",


### PR DESCRIPTION
- Closes #708.

## Summary

- Bump pinned wasm nightly toolchain `nightly-2024-07-18` → `nightly-2025-02-20` in `mopro-ffi/rust-toolchain.toml`, `mopro-ffi/src/app_config/web.rs`, and both `.github/workflows/build-and-test.yml` references.
- Add `-e` to the Linux `script -q -c "..."` invocation in the Build Web step so a failing `mopro build` actually fails the step.
- Add a post-build `test -d MoproWasmBindings` guard that exits with a `::error::` annotation if the wasm bindings weren't produced.

## Why

Full diagnosis in #708. Short version:

1. `nightly-2024-07-18` (cargo 1.81.0-nightly) predates `edition2024`. A transitive dep — `wit-bindgen 0.51.0` / `wit-bindgen-rust-macro 0.51.0` — uses `edition = "2024"`, so cargo refuses to parse its manifest and `wasm-pack build` exits non-zero.
2. Util-linux `script` returns its **own** exit code (0) by default, not the child's, unless `-e` / `--return` is passed. So mopro exited 1, `script` exited 0, the Build Web step reported success with no `MoproWasmBindings/` produced, `actions/cache@v4` skipped the save (`Path Validation Error: Path(s) ... do(es) not exist`), and the downstream `test_halo2_wasm_web` job cache-missed and tried to `yarn install` in a directory that never existed.

The post-build guard is defense in depth: even if a future regression sneaks past the `script -e` change, we catch it at the step that introduced it instead of corrupting a downstream job.

## Out of scope

- The macOS `script -q /dev/null cmd args` form is left untouched — BSD `script` semantics differ and the macOS web path isn't currently in the failing matrix.
- The underlying need for `script` (the `# TODO: allow mopro CLI to run fully non-interactive` comment) is unchanged; a proper fix in the CLI would let us drop the pseudo-TTY entirely. Tracked separately.

## Test plan

- [ ] CI: `cli_build_web (halo2)` succeeds and now actually produces `MoproWasmBindings/`.
- [ ] CI: `test_halo2_wasm_web (halo2)` (which depends on the above) goes green — `yarn install` finds its working directory and the browser test runs.
- [ ] Negative check (eyeballed from the diff): if some future change reintroduces a silent-exit, the new `test -d MoproWasmBindings` guard prints `::error::wasm build did not produce MoproWasmBindings/` and fails the step at the actual point of failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)