### PR TITLE
docs(flutter): fix stale plugin name in pubspec dependency snippet

### DIFF
--- a/docs/docs/setup/flutter-setup.md
+++ b/docs/docs/setup/flutter-setup.md
@@ -99,8 +99,8 @@ Follow the steps below to integrate mopro plugin.
     dependencies:
     flutter:
         sdk: flutter
-    mopro_flutter_plugin:
-        path: ./mopro_flutter_plugin
+    mopro_flutter_bindings:
+        path: ./mopro_flutter_bindings
     ```
 
 ### 2-2. Copy keys in the `assets` folder like this


### PR DESCRIPTION
## Problem

Section **2-1** of the Flutter setup guide (`docs/docs/setup/flutter-setup.md`) tells users to add a `pubspec.yaml` dependency named `mopro_flutter_plugin` at `path: ./mopro_flutter_plugin`:

```yaml
mopro_flutter_plugin:
    path: ./mopro_flutter_plugin
```

But the folder users actually copy in **step 1** — and that's referenced everywhere else on the page — is `mopro_flutter_bindings`:

- Step 1 copies the `mopro_flutter_bindings` folder
- Imports use `package:mopro_flutter_bindings/...`
- "What's next" references `mopro_flutter_bindings`

The `mopro_flutter_plugin` name is a leftover from the old, deprecated plugin-based flow. Since the Dart package is named `mopro_flutter_bindings`, this dependency entry would not resolve. The Mopro CLI that scaffolds these apps also writes `path: ./mopro_flutter_bindings` (`cli/src/create/flutter.rs`), confirming the intended value.

## Fix

Update the section 2-1 snippet to match:

```yaml
mopro_flutter_bindings:
    path: ./mopro_flutter_bindings
```

This was the only occurrence of `mopro_flutter_plugin` in the current docs. The versioned snapshots (`versioned_docs/version-0.1`, `version-0.2`) legitimately use `mopro_flutter_plugin` throughout for their era and are intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Smkp7CuhA7VjLwriicL12a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Smkp7CuhA7VjLwriicL12a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Flutter setup guide to use the local `mopro_flutter_bindings` dependency in the `pubspec.yaml` example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->