### PR TITLE
Remove unnecessary references in Android string formatting

### DIFF
--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -13,10 +13,7 @@ pub fn print_footer_message() {
 }
 
 pub(crate) fn print_init_instructions(project_name: String) {
-    println!(
-        "🚀 Project '{}' initialized successfully! 🎉",
-        project_name
-    );
+    println!("🚀 Project '{}' initialized successfully! 🎉", project_name);
     println!();
     println!("To get started, follow these steps:");
     println!();

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -15,13 +15,13 @@ pub fn print_footer_message() {
 pub(crate) fn print_init_instructions(project_name: String) {
     println!(
         "🚀 Project '{}' initialized successfully! 🎉",
-        &project_name
+        project_name
     );
     println!();
     println!("To get started, follow these steps:");
     println!();
     print_green_bold("1. Navigate to your project directory:".to_string());
-    print_bold(format!("   cd {}", &project_name));
+    print_bold(format!("   cd {}", project_name));
     println!();
     print_green_bold("2. Run the following commands to build and run the project:".to_string());
     print_bold("   mopro build".to_string());

--- a/mopro-ffi/src/app_config/android.rs
+++ b/mopro-ffi/src/app_config/android.rs
@@ -69,9 +69,9 @@ impl PlatformBuilder for AndroidPlatform {
         let out_android_kt_file_name = ANDROID_KT_FILE;
 
         // Names for the generated files by uniffi
-        let lib_name = format!("lib{}.so", &uniffi_style_identifier);
+        let lib_name = format!("lib{}.so", uniffi_style_identifier);
         let gen_android_module_name = &uniffi_style_identifier;
-        let gen_android_kt_file_name = format!("{}.kt", &uniffi_style_identifier);
+        let gen_android_kt_file_name = format!("{}.kt", uniffi_style_identifier);
 
         #[cfg(feature = "witnesscalc")]
         let _ = std::env::var("ANDROID_NDK").context("ANDROID_NDK is not set")?;


### PR DESCRIPTION
## Summary
This PR removes unnecessary reference operators (`&`) in string formatting operations within the Android platform configuration module.

## Key Changes
- Removed `&` reference operator from `uniffi_style_identifier` in `lib_name` format string (line 72)
- Removed `&` reference operator from `uniffi_style_identifier` in `gen_android_kt_file_name` format string (line 75)

## Details
The `format!` macro automatically dereferences arguments, so the explicit `&` operators were redundant. This change improves code clarity by removing unnecessary references while maintaining identical functionality. The `uniffi_style_identifier` variable is already a `String`, and `format!` will handle it correctly without the explicit reference.

https://claude.ai/code/session_01QuAb1MjFT7j5X443dv2u9q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android build compatibility by correcting the generated library and Kotlin file naming behavior.
  * Fixed the CLI’s project initialization instructions to display and format the project name consistently in both the success message and the suggested `cd` command.
  * No changes were made to the public API or other build logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->