### PR TITLE
fix: replace dead ci-keys.zkmopro.org links

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -132,6 +132,18 @@ jobs:
                   export CLASSPATH="$PWD/jna-5.13.0.jar"
                   cargo test --all --all-features
 
+            - name: Build with the rapidsnark feature
+              if: matrix.adapter == 'circom'
+              working-directory: ${{ runner.temp }}/mopro-example-circom
+              run: |
+                  sed -i.bak 's/^circom-prover = "0.1"$/circom-prover = { version = "0.1", features = ["rapidsnark"] }/' Cargo.toml
+                  rm Cargo.toml.bak
+                  grep -q 'features = \["rapidsnark"\]' Cargo.toml || {
+                      echo "::error::failed to enable the rapidsnark feature; the circom-prover entry in write_toml.rs may have changed"
+                      exit 1
+                  }
+                  cargo build
+
     cli_build_ios_prepare:
         needs: cli_build
         strategy:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -139,7 +139,7 @@ jobs:
                   sed -i.bak 's/^circom-prover = "0.1"$/circom-prover = { version = "0.1", features = ["rapidsnark"] }/' Cargo.toml
                   rm Cargo.toml.bak
                   grep -q 'features = \["rapidsnark"\]' Cargo.toml || {
-                      echo "::error::failed to enable the rapidsnark feature; the circom-prover entry in write_toml.rs may have changed"
+                      echo "::error::failed to enable the rapidsnark feature; the circom-prover entry in cli/src/init/circom.rs may have changed"
                       exit 1
                   }
                   cargo build

--- a/docs/blog/2025-03-27-ethtaipei-workshop.md
+++ b/docs/blog/2025-03-27-ethtaipei-workshop.md
@@ -236,8 +236,8 @@ Alternatively, you can watch this video to see how to run the app.
 This section explains how to update circuits with alternative witness generators and corresponding zkey files. We use the [Keccak256 circuit](https://github.com/zkmopro/circuit-registry/blob/main/keccak256/keccak256_256_test.circom) as a reference example here.
 
 1.  Add wasm and zkey file in the `test-vectors/circom` folder
-    -   wasm: https://ci-keys.zkmopro.org/keccak256_256_test.wasm
-    -   zkey: https://ci-keys.zkmopro.org/keccak256_256_test_final.zkey
+    -   wasm: https://raw.githubusercontent.com/zkmopro/rust-rapidsnark/v0.1.4/tests/test-vectors/keccak256_256_test.wasm
+    -   zkey: https://raw.githubusercontent.com/zkmopro/rust-rapidsnark/v0.1.4/tests/test-vectors/keccak256_256_test_final.zkey
 2.  In `src/lib.rs` file, update the circuit's witness generator function definition.
 
     ```diff
@@ -315,7 +315,7 @@ This section explains how to update circuits with alternative witness generators
     + val zkeyPath = getFilePathFromAssets("keccak256_256_test_final.zkey")
     ```
 
--   Update circuit inputs: https://ci-keys.zkmopro.org/keccak256.json
+-   Update circuit inputs: https://raw.githubusercontent.com/zkmopro/circuit-registry/aab2ee1290ecd5d2b7dff985520bd1f3ce8a9750/keccak256/input.json
 
     -   **iOS:**<br/>
 

--- a/docs/docs/adapters/circom.md
+++ b/docs/docs/adapters/circom.md
@@ -302,6 +302,7 @@ Mopro now supports 2 Circom provers. You can find more information in [the blog 
 
 -   `rust-rapidsnark` is based on the original C++ implementation of [rapidsnark](https://github.com/iden3/rapidsnark), with the binary wrapped and integrated in Rust.
 -   Activate `rapidsnark` Feature for both `[dependencies]` and `[build-dependencies]`
+-   No prebuilt covers `x86_64-apple-ios`. To build for the Intel Mac simulator, point `RAPIDSNARK_LIB_DIR` at your own build of those libraries.
 
 ```toml
 [dependencies]

--- a/docs/docs/sdk/react-native.md
+++ b/docs/docs/sdk/react-native.md
@@ -117,7 +117,7 @@ To learn how to read a .zkey file from an app, please refer to the [`loadAssets`
 :::warning
 The default bindings are built specifically for the `multiplier2` circom circuit. If you'd like to update the circuit or switch to a different proving scheme, please refer to the [How to Build the Package](#how-to-build-the-package) section.<br/>
 Circuit source code: https://github.com/zkmopro/circuit-registry/tree/main/multiplier2<br/>
-Example .zkey file for the circuit: http://ci-keys.zkmopro.org/multiplier2_final.zkey<br/>
+Example .zkey file for the circuit: https://raw.githubusercontent.com/zkmopro/mopro/mopro-cli-v0.3.7/cli/src/template/init/test-vectors/circom/multiplier2_final.zkey<br/>
 :::
 
 And in `index.js`, for example, replace this with

--- a/docs/docs/setup/rust-setup.md
+++ b/docs/docs/setup/rust-setup.md
@@ -171,8 +171,8 @@ fn main() {
 Learn more about `.wasm` files in [Circom documentation](https://docs.circom.io/getting-started/compiling-circuits/). <br/>
 Here are the example WASM and Zkey files to be downloaded.
 
--   http://ci-keys.zkmopro.org/multiplier2.wasm
--   http://ci-keys.zkmopro.org/multiplier2_final.zkey
+-   [multiplier2.wasm](https://raw.githubusercontent.com/zkmopro/mopro/mopro-cli-v0.3.7/cli/src/template/init/test-vectors/circom/multiplier2.wasm)
+-   [multiplier2_final.zkey](https://raw.githubusercontent.com/zkmopro/mopro/mopro-cli-v0.3.7/cli/src/template/init/test-vectors/circom/multiplier2_final.zkey)
 
 :::
 

--- a/docs/versioned_docs/version-0.1/setup/react-native-setup.md
+++ b/docs/versioned_docs/version-0.1/setup/react-native-setup.md
@@ -487,7 +487,7 @@ export default function HomeScreen() {
     const [proof, setProof] = useState<string>("");
     async function genProof(): Promise<void> {
         const asset = Asset.fromURI(
-            "https://ci-keys.zkmopro.org/multiplier2_final.zkey"
+            "https://raw.githubusercontent.com/zkmopro/mopro/mopro-cli-v0.3.7/cli/src/template/init/test-vectors/circom/multiplier2_final.zkey"
         );
         const newFileName = "multiplier2_final.zkey";
         const newFilePath = `${FileSystem.documentDirectory}${newFileName}`;

--- a/docs/versioned_docs/version-0.2/setup/rust-setup.md
+++ b/docs/versioned_docs/version-0.2/setup/rust-setup.md
@@ -154,8 +154,8 @@ fn main() {
 Learn more about `.wasm` files in [Circom documentation](https://docs.circom.io/getting-started/compiling-circuits/). <br/>
 Here are the example WASM and Zkey files to be downloaded.
 
--   http://ci-keys.zkmopro.org/multiplier2.wasm
--   http://ci-keys.zkmopro.org/multiplier2_final.zkey
+-   [multiplier2.wasm](https://raw.githubusercontent.com/zkmopro/mopro/mopro-cli-v0.3.7/cli/src/template/init/test-vectors/circom/multiplier2.wasm)
+-   [multiplier2_final.zkey](https://raw.githubusercontent.com/zkmopro/mopro/mopro-cli-v0.3.7/cli/src/template/init/test-vectors/circom/multiplier2_final.zkey)
 
 :::
 


### PR DESCRIPTION
# Fix dead `ci-keys.zkmopro.org` links

- Follow-up to and close #724, alongside zkmopro/rust-rapidsnark#12.

## Problem

`ci-keys.zkmopro.org` no longer resolves (same lapsed zone as `rapidsnark.zkmopro.org`), so the Rust setup guide, React Native SDK page, and EthTaipei workshop all fail with `curl: (6) Could not resolve host`.

## Changes

Every link now points at a fixture already committed in the org, pinned to a tag or commit so it can't drift:

| File | New source |
| --- | --- |
| `multiplier2.wasm`, `multiplier2_final.zkey` | this repo @ `mopro-cli-v0.3.7` |
| keccak256 wasm + zkey | rust-rapidsnark @ `v0.1.4` (only committed copies) |
| `keccak256.json` | circuit-registry `keccak256/input.json` — verified identical to the 256 values the workshop pastes inline |

The 0.1 and 0.2 docs carried the same dead host and are updated too.

**Also:**

- **Circom adapter page** now notes that `rust-rapidsnark` 0.1.4 dropped `x86_64-apple-ios` (upstream builds `libfr.a`/`libfq.a` arm64-only for the simulator). mopro still offers that arch, so an Intel Mac would otherwise fail with no explanation.
- **`cli_template_tests`** now builds a scaffolded circom project with the `rapidsnark` feature enabled. Nothing in CI compiled `rust-rapidsnark` before — scaffolded projects leave the feature off — which is how a download endpoint could break for users while CI stayed green. Runs on both runners; the Ubuntu leg would have caught the Linux link failure in rust-rapidsnark#12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced the scaffold validation to build Circom projects with the Rapidsnark feature enabled.

* **Tests**
  * Added an explicit verification that the required feature is present before building, and improved the related failure message.

* **Documentation**
  * Updated Circom, Rust, React Native, and workshop guides to use newer raw GitHub download links for circuit artifacts and test vectors.
  * Added clarification about missing prebuilt iOS covers and how to build the Intel Mac simulator using a local library path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->